### PR TITLE
Add tag-driven PyPI publishing under the Band PyPI org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          init_version=$(python -c "import re; print(re.search(r'__version__ = \"([^\"]+)\"', open('src/codeband/__init__.py').read()).group(1))")
+          if [ "$tag_version" != "$pkg_version" ] || [ "$tag_version" != "$init_version" ]; then
+            echo "::error::Version drift — tag=$GITHUB_REF_NAME pyproject=$pkg_version __init__=$init_version (all three must match)"
+            exit 1
+          fi
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: release
+      url: https://pypi.org/p/codeband
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ This project is currently in alpha. Until the first stable release, minor versio
 - Added OSS community files, issue templates, and CI workflow.
 - Restructured the README into a shorter landing guide.
 - Added focused authentication, configuration, and troubleshooting docs.
+- Added PyPI publishing workflow (tag-driven, Trusted Publishing under the Band PyPI org) and `RELEASING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ For larger behavior changes, open an issue first so we can agree on the shape be
 ## Development Setup
 
 ```bash
-git clone https://github.com/band-ai/codeband.git
+git clone https://github.com/thenvoi/codeband.git
 cd codeband
 python -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/codeband.svg)](https://pypi.org/project/codeband/)
-[![GitHub stars](https://img.shields.io/github/stars/band-ai/codeband?style=social)](https://github.com/band-ai/codeband)
+[![GitHub stars](https://img.shields.io/github/stars/thenvoi/codeband?style=social)](https://github.com/thenvoi/codeband)
 
 **Adversarial multi-model coding agents via [Band.ai](https://band.ai).**
 
@@ -204,7 +204,7 @@ Current planned work:
 Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), and please open an issue before large behavior changes.
 
 ```bash
-git clone https://github.com/band-ai/codeband.git
+git clone https://github.com/thenvoi/codeband.git
 cd codeband
 pip install -e ".[dev]"
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,96 @@
+# Releasing Codeband
+
+Codeband is published to PyPI as [`codeband`](https://pypi.org/project/codeband/)
+under the [Band PyPI org](https://pypi.org/org/Band/). Releases are cut by
+pushing a `vX.Y.Z` tag; GitHub Actions builds the sdist and wheel and uploads
+them to PyPI via [Trusted Publishing][tp] (OIDC, no API tokens stored).
+
+[tp]: https://docs.pypi.org/trusted-publishers/
+
+## One-time setup (PyPI side)
+
+Done once by a maintainer with admin access to the `Band` PyPI org.
+
+1. Sign in to https://pypi.org as a member of the **Band** org.
+2. Go to **Your account** → **Publishing** → **Add a pending publisher** (use a
+   pending publisher because the `codeband` project does not exist on PyPI yet
+   — the first successful publish creates it under the org).
+3. Fill in:
+   - **PyPI Project Name**: `codeband`
+   - **Owner**: `thenvoi`
+   - **Repository name**: `codeband`
+   - **Workflow name**: `publish.yml`
+   - **Environment name**: `release`
+
+After the first release, the project will appear under
+https://pypi.org/manage/project/codeband/. Future trusted-publisher edits live
+under the project's **Publishing** tab.
+
+## One-time setup (GitHub side)
+
+Done once on the `thenvoi/codeband` repo.
+
+1. Settings → Environments → **New environment** → name it `release`.
+2. (Optional, recommended) Restrict the environment to protected tags matching
+   `v*` so only maintainers can trigger a publish.
+
+## Cutting a release
+
+1. Bump the version in two places — the publish workflow fails the build if
+   they drift:
+   - `pyproject.toml` → `[project] version`
+   - `src/codeband/__init__.py` → `__version__`
+2. Update `CHANGELOG.md`: rename the `Unreleased` section to the new version
+   and add a fresh `Unreleased` heading on top.
+3. Commit and push to `main`.
+4. Tag and push:
+   ```bash
+   git tag -a v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+5. Watch the **Publish to PyPI** workflow under **Actions**. It verifies the
+   tag against both version files, builds, and uploads. Total runtime ~2
+   minutes.
+6. Verify in a clean venv:
+   ```bash
+   pip install --upgrade codeband
+   cb --version
+   ```
+
+## Building locally (smoke test)
+
+```bash
+pip install --upgrade build twine
+python -m build
+twine check dist/*
+```
+
+The repo uses a `src/` layout with `setuptools.packages.find`, so `python -m
+build` produces both an sdist and a wheel under `dist/`. Prompt files are
+bundled via `[tool.setuptools.package-data]`.
+
+## Failure modes
+
+- **Tag/version drift** — the build job's verify step fails before any upload.
+  Fix: delete the bad tag (`git tag -d vX.Y.Z && git push origin
+  :refs/tags/vX.Y.Z`), align the versions, re-tag.
+- **OIDC rejected by PyPI** — confirm the Trusted Publisher entry matches
+  exactly: owner `thenvoi`, repo `codeband`, workflow `publish.yml`,
+  environment `release`. Re-run the failed job from the Actions tab.
+- **Bad release shipped** — you can `yank` a release on PyPI (hides from
+  default `pip install`, keeps it for pinned installs). You cannot delete a
+  version once published. Ship the next patch version with the fix.
+- **Re-publishing the same version** — not allowed by PyPI. Bump and re-tag.
+
+## Manual fallback
+
+If Trusted Publishing is ever unavailable, a maintainer with `Band` org upload
+permissions can publish from a local machine:
+
+```bash
+python -m build
+twine upload dist/*   # uses ~/.pypirc or TWINE_USERNAME/TWINE_PASSWORD
+```
+
+Prefer the tag-driven workflow — it leaves an auditable trail in GitHub
+Actions and avoids any local credential handling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
-[project.urls]
-Homepage = "https://github.com/band-ai/codeband"
-Documentation = "https://github.com/band-ai/codeband#documentation"
-Repository = "https://github.com/band-ai/codeband"
-Issues = "https://github.com/band-ai/codeband/issues"
-Changelog = "https://github.com/band-ai/codeband/blob/main/CHANGELOG.md"
-
 dependencies = [
     "band-sdk[codex,claude-sdk]>=0.2.8",
     "click>=8.1",
@@ -60,6 +53,13 @@ dev = [
 [project.scripts]
 cb = "codeband.cli:cli"
 codeband = "codeband.cli:cli"
+
+[project.urls]
+Homepage = "https://github.com/thenvoi/codeband"
+Documentation = "https://github.com/thenvoi/codeband#documentation"
+Repository = "https://github.com/thenvoi/codeband"
+Issues = "https://github.com/thenvoi/codeband/issues"
+Changelog = "https://github.com/thenvoi/codeband/blob/main/CHANGELOG.md"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary
- New `.github/workflows/publish.yml` — on `v*` tag push, build sdist+wheel, verify the tag matches both `pyproject.toml` and `src/codeband/__init__.py` versions, then upload to PyPI via Trusted Publishing (OIDC, no API tokens). Uses environment `release`, matching the `thenvoi-sdk-python` Band publish job.
- Fix `[project.urls]` placement in `pyproject.toml` — the bare `dependencies` list after the `[project.urls]` table was being parsed as a member of that table, breaking `python -m build`. Moved urls below `[project.scripts]`. Also updated URLs from `band-ai/codeband` (empty placeholder org) to `thenvoi/codeband` (real repo) so PyPI metadata links resolve.
- New `RELEASING.md` documenting one-time PyPI/GitHub setup, the cut-a-release loop, failure modes, and the manual fallback.

This is a fresh PR (does not build on `add-pypi-publishing`); that branch can be deleted once this lands.

## Out-of-band setup before tagging v0.1.0

These can't go in the PR — they need PyPI/GitHub admin access:

1. **PyPI**: sign in as a `Band` org member → **Add a pending publisher** with PyPI project `codeband`, owner `thenvoi`, repo `codeband`, workflow `publish.yml`, environment `release`.
2. **GitHub**: Settings → Environments → create `release` (optional: restrict to `v*` tags).
3. **Repo visibility**: flip `thenvoi/codeband` to Public.
4. Tag `v0.1.0`, push, watch Actions.

Full walkthrough in the new `RELEASING.md`.

## Test plan
- [x] `python -m build` produces both sdist and wheel under `dist/`
- [x] `twine check dist/*` PASSED on both artifacts
- [x] Wheel contains `codeband/prompts/*.md` (verified `setuptools.package-data` still bundles prompts after the urls reorder)
- [ ] (Post-merge) workflow_dispatch smoke run on `main` to confirm the build job parses on Actions
- [ ] (Post-merge) push `v0.1.0` tag and confirm the publish job lands `codeband` on PyPI under the Band org
- [ ] (Post-merge) `pip install codeband` in a clean venv → `cb --version` reports `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)