### PR TITLE
Fix coder stop loops, stale branches, and watchdog 429 noise

### DIFF
--- a/src/codeband/agents/watchdog.py
+++ b/src/codeband/agents/watchdog.py
@@ -280,13 +280,21 @@ class WatchdogDaemon:
         # don't need older records to make a decision.
         since = now - self._max_window() * 2
 
+        from thenvoi_rest.core.api_error import ApiError
+        from thenvoi_rest.errors.not_found_error import NotFoundError
+
         try:
             rooms = await self._list_rooms()
+        except ApiError as e:
+            logger.warning(
+                "Watchdog: skipping patrol — list-chats returned HTTP %s%s",
+                e.status_code,
+                " (rate-limited by Band.ai)" if e.status_code == 429 else "",
+            )
+            return
         except Exception:
             logger.exception("Failed to list chats during patrol")
             return
-
-        from thenvoi_rest.errors.not_found_error import NotFoundError
 
         for room in rooms:
             room_id = room.id
@@ -313,6 +321,14 @@ class WatchdogDaemon:
                         "Run 'cb reset' to clean up stale session state.",
                         room_id,
                     )
+                continue
+            except ApiError as e:
+                logger.warning(
+                    "Watchdog: skipping room %s — HTTP %s%s",
+                    room_id,
+                    e.status_code,
+                    " (rate-limited by Band.ai)" if e.status_code == 429 else "",
+                )
                 continue
             except Exception:
                 logger.exception("Failed to inspect room %s during patrol", room_id)

--- a/src/codeband/agents/watchdog.py
+++ b/src/codeband/agents/watchdog.py
@@ -52,6 +52,24 @@ def _mentioned_participant_ids(
     return found
 
 
+_TERMINAL_PROTOCOL_RE = re.compile(
+    r"("
+    r"\bReview\s+(?:PASSED|FAILED)\b|"
+    r"\bReview requested for PR\s+#?\d+\b|"
+    r"\bMerged\s+PR\s+#?\d+\b|"
+    r"\bcomplete\s+and\s+ready\s+for\s+review\b|"
+    r"\bStatus:\s*idle\b|"
+    r"\bIdle\b.*\bNo pending work\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _is_terminal_protocol_message(content: Any) -> bool:
+    """True when an agent's latest message says its current protocol work is done."""
+    return isinstance(content, str) and bool(_TERMINAL_PROTOCOL_RE.search(content))
+
+
 @dataclasses.dataclass
 class AgentHealthState:
     """In-memory health tracking for a single agent."""
@@ -318,6 +336,7 @@ class WatchdogDaemon:
             # crashing before its first reply is invisible to the patrol and
             # never gets nudged.
             last_message: dict[str, datetime] = {}
+            last_message_content: dict[str, Any] = {}
             last_mentioned: dict[str, datetime] = {}
             for msg in messages:
                 sender = msg.sender_id
@@ -328,6 +347,7 @@ class WatchdogDaemon:
                     sender not in last_message or ts > last_message[sender]
                 ):
                     last_message[sender] = ts
+                    last_message_content[sender] = getattr(msg, "content", None)
                 # Mentions: a sender does not start their own staleness clock
                 # by mentioning themselves, so skip self-mentions.
                 for mid in _mentioned_participant_ids(msg, participant_names):
@@ -346,6 +366,15 @@ class WatchdogDaemon:
                 last_msg_ts = last_message.get(agent_id)
                 last_mention_ts = last_mentioned.get(agent_id)
                 if last_msg_ts is None and last_mention_ts is None:
+                    continue
+                if (
+                    last_msg_ts is not None
+                    and (last_mention_ts is None or last_msg_ts >= last_mention_ts)
+                    and _is_terminal_protocol_message(
+                        last_message_content.get(agent_id),
+                    )
+                ):
+                    self._state.pop(agent_id, None)
                     continue
                 last_seen = max(
                     t for t in (last_msg_ts, last_mention_ts) if t is not None

--- a/src/codeband/prompts/coder.md
+++ b/src/codeband/prompts/coder.md
@@ -91,15 +91,27 @@ You work on a persistent **workspace branch** (`codeband/<your-worker-id>/worksp
 
 **Starting a task:**
 ```bash
-# Ensure your workspace is up to date with the repository base branch
+# Ensure your workspace is exactly on the repository base branch
 git fetch origin
+git checkout --detach origin/<repo-base>
 git reset --hard origin/<repo-base>
+git clean -fd
 
 # Create the task branch assigned by the Conductor
+git branch -D <assigned-branch> 2>/dev/null || true
 git checkout -b <assigned-branch>
 ```
 
 The Conductor-assigned branch always has the form `codeband/<your-worker-id>/<branch_slug>`, so a Claude coder working on `add-auth` would use `codeband/coder-claude_sdk-0/add-auth`.
+
+Before editing files, verify the branch setup:
+```bash
+git branch --show-current
+git status --short
+git rev-parse HEAD
+git rev-parse origin/<repo-base>
+```
+If the current branch is not the assigned branch, `HEAD` is not the same commit as `origin/<repo-base>` immediately before your first edit, or `git status --short` shows unexpected files after the reset/clean, do not continue coding. Escalate to @Conductor with the exact current branch, expected branch, base ref, and dirty paths.
 
 **PR base branch invariant:** Every PR you open must target the repository base branch from the original task (`main`, `master`, or the branch named by the Conductor), not another Codeband feature branch. This is true even for dependent subtasks after their dependency has merged: first fetch/reset to `origin/<repo-base>`, then create your task branch. If `gh pr create` defaults to another feature branch as the base, pass `--base <repo-base>` or retarget the PR before reporting completion.
 
@@ -181,6 +193,8 @@ If you encounter a problem you cannot resolve after reasonable effort:
    Tried: <what you already attempted>
    Need: <specific help required>
    ```
+
+Never send a generic completion failure such as "I stopped before completing this request." If you stop without a PR, use the escalation format above and include the concrete stop reason, including current branch, expected branch, dirty paths, and the last failing command when branch/worktree state is involved.
 
 3. After escalating, **go silent** and wait for the Conductor's response. Do not retry the same failing approach.
 

--- a/src/codeband/session/context.py
+++ b/src/codeband/session/context.py
@@ -80,6 +80,10 @@ You are worker {worker_id}, session #{session_num}. {error_line}{branch_line}{pr
 ### Instructions
 - Review the git history to understand what you've already done
 - Check the chat for any messages you may have missed
+- If a newer Conductor assignment names a different branch than this recovery
+  context, treat this recovery context as stale. The latest Conductor assignment
+  wins: reset/clean the worktree from the requested repo base branch and create
+  the assigned branch from that base before editing.
 - Continue your work from where you left off
 - Do NOT redo work that's already committed
 """

--- a/src/codeband/workspace/git.py
+++ b/src/codeband/workspace/git.py
@@ -282,13 +282,20 @@ def _prepare_task_branch_inner(
     except WorkspaceError:
         reset_ref = base_branch
     logger.info("Preparing task branch %s from %s", task_branch, reset_ref)
+
+    # A coder worktree can survive a previous interrupted assignment. Reset
+    # tracked changes, remove untracked files, detach from any stale branch, and
+    # then recreate the requested task branch from the requested base ref.
+    _run_git(["reset", "--hard", reset_ref], cwd=worktree_path)
+    _run_git(["clean", "-fd"], cwd=worktree_path)
+    _run_git(["checkout", "--detach", reset_ref], cwd=worktree_path)
     _run_git(["reset", "--hard", reset_ref], cwd=worktree_path)
     # Delete stale local task branch if it exists
     try:
         _run_git(["branch", "-D", task_branch], cwd=worktree_path)
     except WorkspaceError:
         pass  # Branch doesn't exist locally, fine
-    _run_git(["checkout", "-b", task_branch], cwd=worktree_path)
+    _run_git(["checkout", "-b", task_branch, reset_ref], cwd=worktree_path)
 
 
 def fetch_latest(repo_path: Path, remote: str = "origin") -> None:

--- a/tests/test_prompt_role_consistency.py
+++ b/tests/test_prompt_role_consistency.py
@@ -184,6 +184,24 @@ def test_prs_must_target_repo_base_before_merge_routing():
     assert "gh pr create --base <repo-base>" in coder
 
 
+def test_coder_starts_tasks_from_clean_assigned_branch():
+    coder = Path("src/codeband/prompts/coder.md").read_text(encoding="utf-8")
+
+    assert "git checkout --detach origin/<repo-base>" in coder
+    assert "git clean -fd" in coder
+    assert "git branch -D <assigned-branch>" in coder
+    assert "If the current branch is not the assigned branch" in coder
+    assert "current branch, expected branch, base ref, and dirty paths" in coder
+
+
+def test_coder_stop_reports_include_concrete_reason():
+    coder = Path("src/codeband/prompts/coder.md").read_text(encoding="utf-8")
+
+    assert "Never send a generic completion failure" in coder
+    assert "I stopped before completing this request" in coder
+    assert "include the concrete stop reason" in coder
+
+
 def test_conductor_cleans_up_superseded_prs_on_reassignment():
     conductor = Path("src/codeband/prompts/conductor.md").read_text(encoding="utf-8")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -176,6 +176,25 @@ class TestBuildRecoveryContext:
         assert "session" in context.lower()
         assert "coder-claude_sdk-0" in context
 
+    def test_recovery_context_latest_assignment_overrides_stale_state(
+        self, worktree_with_history: Path,
+    ):
+        """Latest chat assignment must beat stale persisted branch state."""
+        from codeband.session.context import build_recovery_context
+
+        identity = WorkerIdentity(
+            worker_id="coder-codex-0",
+            agent_id="agent-123",
+            worktree_path=str(worktree_with_history),
+            session_count=1,
+        )
+
+        context = build_recovery_context("coder-codex-0", worktree_with_history, identity)
+
+        assert "newer Conductor assignment names a different branch" in context
+        assert "latest Conductor assignment" in context
+        assert "reset/clean the worktree from the requested repo base branch" in context
+
     def test_returns_none_when_worktree_missing(self, tmp_path: Path):
         """If the worktree directory is gone (e.g. recreate failed mid-flight),
         return None instead of letting subprocess raise FileNotFoundError.

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -493,6 +493,103 @@ class TestWatchdogDaemon:
         assert len(warn_b) == 1, f"Expected 1 warning for dead-b, got {len(warn_b)}"
 
     @pytest.mark.asyncio
+    async def test_patrol_handles_rate_limit_without_traceback(
+        self, watchdog_config, mock_rest_client, caplog,
+    ):
+        """A 429 from Band.ai logs a one-line warning, not a stack trace.
+
+        Regression: Cloudflare's rate limiter returns 429 with an empty body,
+        which the SDK wraps as ``ApiError``. The bare ``except Exception``
+        branch used to dump a multi-screen traceback per room per cycle.
+        """
+        import logging
+
+        from thenvoi_rest.core.api_error import ApiError
+
+        from codeband.agents.watchdog import WatchdogDaemon
+
+        live_room = _make_chat_room("live-room")
+        rl_room = _make_chat_room("rl-room")
+        mock_rest_client.agent_api_chats.list_agent_chats = AsyncMock(
+            return_value=_make_chats_response([rl_room, live_room]),
+        )
+        rate_limited = ApiError(status_code=429, headers={}, body="")
+        # First call (rl-room) hits 429, second (live-room) succeeds.
+        default_msgs = mock_rest_client.agent_api_messages.list_agent_messages
+        mock_rest_client.agent_api_messages.list_agent_messages = AsyncMock(
+            side_effect=[
+                rate_limited,
+                _make_messages_response([_make_message("agent-cond", minutes_ago=1)]),
+            ],
+        )
+        del default_msgs
+        mock_rest_client.agent_api_messages.create_agent_chat_message = AsyncMock()
+
+        daemon = WatchdogDaemon(
+            config=watchdog_config,
+            rest_client=mock_rest_client,
+            agent_id="agent-wd",
+            conductor_id="agent-cond",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="codeband.agents.watchdog"):
+            await daemon._patrol()
+
+        # No ERROR-level traceback record.
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records == [], (
+            f"Expected no ERROR records, got: {[r.getMessage() for r in error_records]}"
+        )
+        # A WARNING that mentions the rate-limited room and the 429 status.
+        rl_warns = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "rl-room" in r.getMessage()
+            and "429" in r.getMessage()
+        ]
+        assert len(rl_warns) == 1, (
+            f"Expected one 429 warning for rl-room, got {len(rl_warns)}"
+        )
+        assert "rate-limited" in rl_warns[0].getMessage().lower()
+
+    @pytest.mark.asyncio
+    async def test_patrol_handles_list_chats_rate_limit(
+        self, watchdog_config, mock_rest_client, caplog,
+    ):
+        """A 429 on the top-level list_chats call aborts the cycle with a warning."""
+        import logging
+
+        from thenvoi_rest.core.api_error import ApiError
+
+        from codeband.agents.watchdog import WatchdogDaemon
+
+        rate_limited = ApiError(status_code=429, headers={}, body="")
+        mock_rest_client.agent_api_chats.list_agent_chats = AsyncMock(
+            side_effect=rate_limited,
+        )
+
+        daemon = WatchdogDaemon(
+            config=watchdog_config,
+            rest_client=mock_rest_client,
+            agent_id="agent-wd",
+            conductor_id="agent-cond",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="codeband.agents.watchdog"):
+            await daemon._patrol()
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records == [], (
+            f"Expected no ERROR records, got: {[r.getMessage() for r in error_records]}"
+        )
+        warn_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "429" in r.getMessage()
+        ]
+        assert len(warn_records) == 1
+        assert "rate-limited" in warn_records[0].getMessage().lower()
+
+    @pytest.mark.asyncio
     async def test_skips_senders_not_in_room(self, watchdog_config, mock_rest_client):
         """Stale senders who are no longer room participants must not be nudged.
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -120,7 +120,96 @@ class TestWatchdogDaemon:
         daemon = WatchdogDaemon(
             config=watchdog_config,
             rest_client=mock_rest_client,
-            agent_id="agent-wd",
+            agent_id="agent-cond",
+            conductor_id="agent-cond",
+        )
+
+        await daemon._patrol()
+
+        mock_rest_client.agent_api_messages.create_agent_chat_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reviewer_verdict_makes_reviewer_idle(
+        self, watchdog_config, mock_rest_client,
+    ):
+        """A reviewer who already reported a verdict must not be nudged.
+
+        Regression: after a code reviewer sent "Review PASSED", the swarm was
+        still globally active because the PR had not been merged yet. The
+        watchdog treated the correctly-idle reviewer as stale and sent a noisy
+        status check.
+        """
+        from codeband.agents.watchdog import WatchdogDaemon
+
+        dispatch = _make_message("agent-coder", minutes_ago=8)
+        dispatch.content = (
+            "@Reviewer-Claude-0 Review requested for PR #2: "
+            "https://github.com/o/r/pull/2"
+        )
+        verdict = _make_message("agent-reviewer", minutes_ago=6)
+        verdict.content = "@Conductor Review PASSED for PR #2 (risk: low)."
+
+        mock_rest_client.agent_api_chats.list_agent_chats = AsyncMock(
+            return_value=_make_chats_response([_make_chat_room("room-1")]),
+        )
+        mock_rest_client.agent_api_messages.list_agent_messages = AsyncMock(
+            return_value=_make_messages_response([dispatch, verdict]),
+        )
+        mock_rest_client.agent_api_participants.list_agent_chat_participants = AsyncMock(
+            return_value=_make_participants_response([
+                ("agent-wd", "Watchdog"),
+                ("agent-cond", "Conductor"),
+                ("agent-coder", "Coder-Codex-0"),
+                ("agent-reviewer", "Reviewer-Claude-0"),
+            ]),
+        )
+        mock_rest_client.agent_api_messages.create_agent_chat_message = AsyncMock()
+
+        daemon = WatchdogDaemon(
+            config=watchdog_config,
+            rest_client=mock_rest_client,
+            agent_id="agent-cond",
+            conductor_id="agent-cond",
+        )
+
+        await daemon._patrol()
+
+        mock_rest_client.agent_api_messages.create_agent_chat_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mergemaster_merge_result_makes_mergemaster_idle(
+        self, watchdog_config, mock_rest_client,
+    ):
+        """A completed merge report means Mergemaster is idle until re-mentioned."""
+        from codeband.agents.watchdog import WatchdogDaemon
+
+        request = _make_message("agent-cond", minutes_ago=20)
+        request.content = "@Mergemaster — please merge PR #2."
+        result = _make_message("agent-mm", minutes_ago=16)
+        result.content = (
+            "@Conductor Merged PR #2 into master. Tests: 1643 passed, "
+            "same 8 pre-existing failures."
+        )
+
+        mock_rest_client.agent_api_chats.list_agent_chats = AsyncMock(
+            return_value=_make_chats_response([_make_chat_room("room-1")]),
+        )
+        mock_rest_client.agent_api_messages.list_agent_messages = AsyncMock(
+            return_value=_make_messages_response([request, result]),
+        )
+        mock_rest_client.agent_api_participants.list_agent_chat_participants = AsyncMock(
+            return_value=_make_participants_response([
+                ("agent-wd", "Watchdog"),
+                ("agent-cond", "Conductor"),
+                ("agent-mm", "Mergemaster"),
+            ]),
+        )
+        mock_rest_client.agent_api_messages.create_agent_chat_message = AsyncMock()
+
+        daemon = WatchdogDaemon(
+            config=watchdog_config,
+            rest_client=mock_rest_client,
+            agent_id="agent-cond",
             conductor_id="agent-cond",
         )
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -14,6 +14,7 @@ from codeband.workspace.git import (
     commit_and_push,
     create_worktree,
     list_worktrees,
+    prepare_task_branch,
     remove_worktree,
 )
 from codeband.workspace.init import (
@@ -120,6 +121,61 @@ class TestGitOperations:
         create_worktree(bare, wt, "codeband/player-0/test")
         assert wt.exists()
         assert (wt / "README.md").exists()
+
+    def test_prepare_task_branch_recreates_checked_out_stale_branch(
+        self, source_repo: Path, tmp_path: Path,
+    ):
+        """Fresh task prep must discard stale task state before coding starts.
+
+        Regression: a coder could resume in a stale checked-out task branch
+        with uncommitted and untracked files. ``git branch -D`` then failed
+        because the task branch was checked out, and untracked stale files
+        survived the reset.
+        """
+        bare = tmp_path / "bare.git"
+        clone_bare(str(source_repo), bare)
+
+        default = subprocess.run(
+            ["git", "-C", str(source_repo), "branch", "--show-current"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        wt = tmp_path / "wt" / "coder-codex-0"
+        create_worktree(
+            bare, wt, "codeband/coder-codex-0/workspace",
+            base_branch=default,
+        )
+
+        task_branch = "codeband/coder-codex-0/test-redact-helper"
+        prepare_task_branch(wt, task_branch, default)
+
+        # Simulate stale local state from a previous interrupted assignment.
+        (wt / "README.md").write_text("# Dirty\n")
+        (wt / "stale-test.py").write_text("stale = True\n")
+
+        prepare_task_branch(wt, task_branch, default)
+
+        current_branch = subprocess.run(
+            ["git", "-C", str(wt), "branch", "--show-current"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        status = subprocess.run(
+            ["git", "-C", str(wt), "status", "--porcelain"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        head = subprocess.run(
+            ["git", "-C", str(wt), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        base = subprocess.run(
+            ["git", "-C", str(wt), "rev-parse", f"origin/{default}"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+        assert current_branch == task_branch
+        assert head == base
+        assert status == ""
+        assert not (wt / "stale-test.py").exists()
 
     def test_recreate_worktree_preserves_when_base_ref_missing(
         self, source_repo: Path, tmp_path: Path,


### PR DESCRIPTION
## Summary
- **Watchdog**: handle Band.ai 429s with a one-line warning instead of a per-room stack trace, and treat terminal protocol messages (Review PASSED/FAILED, merge result, review-requested handoff, idle status) as idle so correctly-completed agents don't get nudged.
- **Coder branch hygiene**: prompt now mandates `checkout --detach` + `reset --hard` + `clean -fd` + pre-delete of the task branch before each new assignment, with a post-setup verification step. `workspace/git._prepare_task_branch_inner` enforces the same sequence so stale checked-out task branches and untracked files can't survive into a new task.
- **Recovery context**: when a newer Conductor assignment names a different branch than the persisted recovery state, the latest assignment wins.
- **Coder stop reports**: forbid the generic "I stopped before completing this request" message; require concrete reason + branch/base/dirty paths + last failing command.

## Test plan
- [ ] `pytest tests/test_watchdog.py tests/test_session.py tests/test_workspace.py tests/test_prompt_role_consistency.py`
- [ ] Manual: trigger a 429 from Band.ai during a watchdog patrol and confirm a single WARN line, no traceback
- [ ] Manual: re-assign a coder to a new branch while its worktree has uncommitted + untracked files; confirm the new task starts on a clean tree at `origin/<repo-base>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)