### PR TITLE
Recommend uv tool install for end-user installs (closes #7)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
+If you prefer [`uv`](https://docs.astral.sh/uv/), the equivalent is `uv venv && source .venv/bin/activate && uv pip install -e ".[dev]"`.
+
 Run the checks before opening a pull request:
 
 ```bash

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -346,7 +346,7 @@ docker run -d --name mergemaster \
 **Without Docker (Python directly):**
 
 ```bash
-pip install codeband
+uv tool install codeband   # or: pipx install codeband / pip install codeband
 cb run --agent coder-claude_sdk-0
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ Distributed mode requires paid Band.ai memory. On free-tier Band.ai, use local o
 ## Quick Start
 
 ```bash
-pip install codeband
+uv tool install codeband   # or: pipx install codeband / pip install codeband
 cd my-project
 cb init --repo https://github.com/myorg/myrepo.git
 cp .env.example .env
 ```
+
+We recommend [`uv tool`](https://docs.astral.sh/uv/concepts/tools/) because it auto-manages the Python toolchain and installs `codeband` into its own isolated venv, avoiding conflicts with other tools in your environment. `pipx install codeband` is the equivalent pre-uv option. Plain `pip install codeband` also works if you are installing into an existing venv you manage. Don't have `uv`? Install it from [astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/) (one-liner curl) and run `uv tool update-shell` once so `cb` lands on your PATH.
 
 Edit `.env`:
 
@@ -218,7 +220,7 @@ Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md), and pl
 ```bash
 git clone https://github.com/thenvoi/codeband.git
 cd codeband
-pip install -e ".[dev]"
+pip install -e ".[dev]"          # or: uv pip install -e ".[dev]"
 
 pytest
 ruff check src/ tests/

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -101,7 +101,7 @@ If local state is disposable, delete the workspace and let Codeband rebuild it o
 
 ### `cb up` cannot find `docker-compose.yml`
 
-`cb up` needs the Docker assets from the source repository. If you installed with `pip install codeband`, clone the repository and run from that checkout, or copy the `docker/` directory into your project.
+`cb up` needs the Docker assets from the source repository. If you installed Codeband from PyPI (via `uv tool`, `pipx`, or `pip`), clone the repository and run from that checkout, or copy the `docker/` directory into your project.
 
 ### Git clone or fetch timeouts
 


### PR DESCRIPTION
## Summary

Addresses [#7](https://github.com/thenvoi/codeband/issues/7) — @asaf-kali suggested switching the install instructions to `uv tool install codeband`.

The suggestion is sound, but rather than replacing `pip install codeband` outright I am recommending `uv tool` as the **primary** path while keeping `pipx` and `pip` as alternatives. This avoids forcing a tool-choice on users already invested in pipx or working inside an existing venv.

- **README.md** — Quick Start now leads with `uv tool install codeband` (single bash block, alternatives shown inline as a comment) plus a short paragraph explaining why uv is preferred (PEP 668 / externally-managed-environments breakage on Homebrew/apt Pythons, isolated venv, auto-managed Python toolchain) and how to bootstrap uv itself.
- **README.md** — Contributing section adds `uv pip install -e ".[dev]"` as an inline alternative; the canonical `pip install -e ".[dev]"` remains the primary instruction.
- **CONTRIBUTING.md** — Dev setup adds the equivalent uv-based workflow (`uv venv && source .venv/bin/activate && uv pip install -e ".[dev]"`).
- **DEPLOYMENT.md** — \"Without Docker\" worker install matches the README format.
- **docs/TROUBLESHOOTING.md** — Replaced \"installed with `pip install codeband`\" wording with a tool-agnostic \"installed from PyPI (via `uv tool`, `pipx`, or `pip`)\".

## What I deliberately did not change

- `pyproject.toml`, the build backend, and `[project.scripts]` entry points — already standard PEP 621, so `uv tool install codeband` works against the existing PyPI release with zero packaging work.
- The dev-loop install (`pip install -e \".[dev]\"`) — `uv tool` is for end-user CLI installs, not contributor workflows. Mentioned as an alternative only.
- `CLAUDE.md` line 8 — internal dev cheatsheet, not user-facing.
- `cb doctor` — out of scope to start introspecting how codeband itself was installed.

## Test plan

- [ ] Render README and confirm the new Quick Start block reads cleanly and the surrounding flow is preserved.
- [ ] `uv tool install --from . codeband` in a clean shell, then `cb --help` resolves on PATH (after `uv tool update-shell` if needed).
- [ ] `pipx install --editable .` still works as the fallback for users who prefer pipx.
- [ ] `pip install -e ".[dev]" && pytest && ruff check src/ tests/` still works for contributors.