### PR TITLE
Fix #9: Add history flag to cb feed command

### DIFF
--- a/src/codeband/cli.py
+++ b/src/codeband/cli.py
@@ -1164,10 +1164,11 @@ def reset(project_dir: str) -> None:
 @click.option("--type", "event_type", default=None, help="Filter by message type (comma-separated)")
 @click.option("--no-thoughts", is_flag=True, help="Hide agent thinking")
 @click.option("--verbose", is_flag=True, help="Show full event content")
+@click.option("--history", "-H", is_flag=True, help="Replay existing room history before streaming new activity")
 @click.option("--dir", "project_dir", default=".", help="Project directory")
 @_project_aware
 def feed(agent: str | None, event_type: str | None, no_thoughts: bool,
-         verbose: bool, project_dir: str) -> None:
+         verbose: bool, history: bool, project_dir: str) -> None:
     """Live stream of agent activity from Band.ai."""
     import os
 
@@ -1198,7 +1199,13 @@ def feed(agent: str | None, event_type: str | None, no_thoughts: bool,
     from thenvoi.client.rest import AsyncRestClient
 
     rest = AsyncRestClient(api_key=api_key, base_url=config.band.rest_url)
-    live_feed = LiveFeed(rest, formatter)
+
+    if history:
+        click.echo("● Live feed — replaying history, then streaming new activity. Ctrl-C to stop.", err=True)
+    else:
+        click.echo("● Live feed — watching for new activity (live only). Run 'cb log' for history. Ctrl-C to stop.", err=True)
+
+    live_feed = LiveFeed(rest, formatter, show_history=history)
     _run_async(live_feed.run())
 
 


### PR DESCRIPTION
Closes #9

### Description
This PR fixes the issue where the `cb feed` command lacked access to historical room data. 

**Changes made:**
* Added the `--history` (`-H`) flag to the `feed` command in `src/codeband/cli.py`.
* Updated the `LiveFeed` initialization to properly pass `show_history=history`.
* Added informational startup banners to `stderr` indicating whether the feed is live-only or replaying history before streaming.