### PR TITLE
Make `cb reset` clear all stale rooms (not just the active one)

### DIFF
--- a/src/codeband/agents/watchdog.py
+++ b/src/codeband/agents/watchdog.py
@@ -311,14 +311,16 @@ class WatchdogDaemon:
             except NotFoundError:
                 # Room was deleted server-side but still appears in the agent's
                 # chat listing (stale Band.ai state from a prior session).
-                # Skip quietly — running `cb reset` before the next session
-                # removes the agent from the stale room. Warn once per room
-                # so the diagnostic is visible without spamming every patrol.
+                # Skip quietly — `cb reset` removes the agents from these stale
+                # rooms (it scans every room, not just the active one). Warn once
+                # per room so the diagnostic is visible without spamming every
+                # patrol.
                 if room_id not in self._warned_stale_rooms:
                     self._warned_stale_rooms.add(room_id)
                     logger.warning(
-                        "Room %s no longer exists — skipping. "
-                        "Run 'cb reset' to clean up stale session state.",
+                        "Room %s no longer exists (stale Band.ai membership from a "
+                        "prior session) — skipping. Run 'cb reset' to clear stale "
+                        "room memberships.",
                         room_id,
                     )
                 continue

--- a/src/codeband/cli.py
+++ b/src/codeband/cli.py
@@ -1146,22 +1146,23 @@ def down(project_dir: str, volumes: bool) -> None:
 @click.option("--dir", "project_dir", default=".", help="Project directory")
 @_project_aware
 def reset(project_dir: str) -> None:
-    """Clean up the active Band.ai task room.
+    """Clean up stale Band.ai task rooms.
 
-    Removes every agent from the room recorded in .codeband_room and deletes
-    the pointer file. Use this when the previous session left stale room
-    membership causing 404 warnings on startup.
+    Removes the agents from every room they still belong to that no longer
+    exists server-side (the stale rooms behind the 404 warnings on startup).
+    Live/active task rooms are left untouched, and rooms are never deleted —
+    only the agents leave. Also clears the .codeband_room pointer.
     """
     project = Path(project_dir).resolve()
     config = load_config(project)
 
-    from codeband.orchestration.kickoff import reset_active_room
+    from codeband.orchestration.kickoff import reset_stale_rooms
 
-    room_id = _run_async(reset_active_room(config, project))
-    if room_id is None:
-        click.echo("No active task room to reset.")
+    room_ids = _run_async(reset_stale_rooms(config, project))
+    if not room_ids:
+        click.echo("No stale rooms to reset.")
     else:
-        click.echo(f"Reset task room: {room_id}")
+        click.echo(f"Cleared agents from {len(room_ids)} stale room(s): {', '.join(room_ids)}")
 
 
 @cli.command()

--- a/src/codeband/orchestration/kickoff.py
+++ b/src/codeband/orchestration/kickoff.py
@@ -409,23 +409,50 @@ async def _cleanup_rooms(
     await _remove_agents_from_room(prev_room_id, agent_config, config)
 
 
-async def reset_active_room(config: CodebandConfig, project_dir: Path) -> str | None:
-    """Remove all agents from the active task room and delete the pointer file.
+async def reset_stale_rooms(config: CodebandConfig, project_dir: Path) -> list[str]:
+    """Remove this deployment's agents from stale Band.ai rooms.
 
-    Returns the room id that was cleaned up, or None if there was nothing to
-    reset. Safe to call repeatedly — missing file or dead-on-Band room both
-    reduce to a no-op.
+    Lists the rooms the Conductor agent is still a member of — the same source
+    the Watchdog patrols (``agent_api_chats.list_agent_chats``) — and, for each
+    room that is *stale* (a participant read returns 404, exactly the Watchdog's
+    staleness signal), removes every agent from it. Live rooms (participant read
+    succeeds) are skipped, so concurrent Codeband task rooms are never disturbed.
+    Removal only drops participants; it never deletes a room. The
+    ``.codeband_room`` pointer is cleared too.
+
+    Best-effort: a truly phantom server-side membership may also 404 on removal
+    and keep being returned by Band.ai. Safe to call repeatedly; a listing
+    failure (offline, rate-limited) reduces to a no-op.
+
+    Returns the list of stale room ids it attempted to clear.
     """
-    room_file = project_dir / ".codeband_room"
-    try:
-        room_id = room_file.read_text(encoding="utf-8").strip()
-    except FileNotFoundError:
-        return None
-    if not room_id:
-        room_file.unlink(missing_ok=True)
-        return None
+    from thenvoi_rest import AsyncRestClient
+    from thenvoi_rest.core.api_error import ApiError
+    from thenvoi_rest.errors.not_found_error import NotFoundError
 
     agent_config = load_agent_config(project_dir)
-    await _remove_agents_from_room(room_id, agent_config, config)
-    room_file.unlink(missing_ok=True)
-    return room_id
+    conductor = agent_config.get("conductor")
+    client = AsyncRestClient(api_key=conductor.api_key, base_url=config.band.rest_url)
+
+    try:
+        resp = await client.agent_api_chats.list_agent_chats()
+        rooms = list(resp.data or [])
+    except Exception as e:  # offline / rate-limited / API error — nothing to do
+        logger.warning("Could not list rooms during reset: %s", e)
+        rooms = []
+
+    cleared: list[str] = []
+    for room in rooms:
+        room_id = room.id
+        try:
+            await client.agent_api_participants.list_agent_chat_participants(chat_id=room_id)
+        except NotFoundError:
+            # Stale: in the agent's chat list but gone server-side. Drop agents.
+            await _remove_agents_from_room(room_id, agent_config, config)
+            cleared.append(room_id)
+        except ApiError as e:
+            # Ambiguous (rate-limit, transient) — leave the room alone.
+            logger.debug("Skipping room %s during reset — HTTP %s", room_id, e.status_code)
+
+    (project_dir / ".codeband_room").unlink(missing_ok=True)
+    return cleared

--- a/tests/test_kickoff.py
+++ b/tests/test_kickoff.py
@@ -435,35 +435,20 @@ class TestSendTask:
         assert "branch: main" in msg.content
 
 
-class TestResetActiveRoom:
-    """Tests for reset_active_room — Band.ai cleanup helper behind `cb reset`."""
+class TestResetStaleRooms:
+    """Tests for reset_stale_rooms — Band.ai cleanup helper behind `cb reset`.
+
+    Only rooms that are stale (participant read 404s — the Watchdog's own
+    staleness signal) get their agents removed; live rooms are skipped so
+    concurrent task rooms are never disturbed. Rooms are never deleted.
+    """
 
     @pytest.mark.asyncio
-    async def test_no_room_file_is_noop(self, sample_config, tmp_path):
-        """Returns None when .codeband_room is missing — no API calls made."""
-        from codeband.orchestration.kickoff import reset_active_room
-        result = await reset_active_room(sample_config, tmp_path)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_empty_room_file_deletes_and_noops(self, sample_config, tmp_path):
-        """Empty pointer file is cleaned up; returns None; no API calls."""
-        from codeband.orchestration.kickoff import reset_active_room
-        (tmp_path / ".codeband_room").write_text("", encoding="utf-8")
-        result = await reset_active_room(sample_config, tmp_path)
-        assert result is None
-        assert not (tmp_path / ".codeband_room").exists()
-
-    @pytest.mark.asyncio
-    async def test_removes_all_agents_and_deletes_pointer(
-        self, sample_config, sample_agent_config, tmp_path,
-    ):
-        """Each agent's client calls remove_agent_chat_participant; pointer is deleted."""
+    async def test_no_rooms_is_noop(self, sample_config, sample_agent_config, tmp_path):
+        """Empty chat list and no pointer → returns [], makes no removals."""
         from codeband.orchestration import kickoff
 
         sample_agent_config.to_yaml(tmp_path / "agent_config.yaml")
-        (tmp_path / ".codeband_room").write_text("stale-room-id", encoding="utf-8")
-
         factory = _make_clients(AsyncMock(), {
             creds.api_key: (creds.agent_id, key)
             for key, creds in sample_agent_config.agents.items()
@@ -473,52 +458,81 @@ class TestResetActiveRoom:
         original = thenvoi_rest.AsyncRestClient
         thenvoi_rest.AsyncRestClient = factory
         try:
-            result = await kickoff.reset_active_room(sample_config, tmp_path)
+            result = await kickoff.reset_stale_rooms(sample_config, tmp_path)
         finally:
             thenvoi_rest.AsyncRestClient = original
 
-        assert result == "stale-room-id"
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_listing_failure_is_non_fatal(
+        self, sample_config, sample_agent_config, tmp_path,
+    ):
+        """If list_agent_chats raises, reset returns [] instead of crashing."""
+        from codeband.orchestration import kickoff
+
+        sample_agent_config.to_yaml(tmp_path / "agent_config.yaml")
+        factory = _make_clients(AsyncMock(), {
+            creds.api_key: (creds.agent_id, key)
+            for key, creds in sample_agent_config.agents.items()
+        })
+        factory("key-cond").agent_api_chats.list_agent_chats.side_effect = RuntimeError("boom")
+
+        import thenvoi_rest
+        original = thenvoi_rest.AsyncRestClient
+        thenvoi_rest.AsyncRestClient = factory
+        try:
+            result = await kickoff.reset_stale_rooms(sample_config, tmp_path)
+        finally:
+            thenvoi_rest.AsyncRestClient = original
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_only_stale_rooms_cleared_live_untouched(
+        self, sample_config, sample_agent_config, tmp_path,
+    ):
+        """Stale rooms (participant read 404) lose all agents; live rooms are skipped."""
+        from thenvoi_rest.errors.not_found_error import NotFoundError
+
+        from codeband.orchestration import kickoff
+
+        sample_agent_config.to_yaml(tmp_path / "agent_config.yaml")
+        (tmp_path / ".codeband_room").write_text("stale-room", encoding="utf-8")
+
+        factory = _make_clients(AsyncMock(), {
+            creds.api_key: (creds.agent_id, key)
+            for key, creds in sample_agent_config.agents.items()
+        })
+
+        # Conductor client drives both the room listing and the staleness probe.
+        cond = factory("key-cond")
+        cond.agent_api_chats.list_agent_chats.return_value = FakeListResponse(
+            data=[FakeRoom("stale-room"), FakeRoom("live-room")]
+        )
+
+        def participants(chat_id):
+            if chat_id == "stale-room":
+                raise NotFoundError(body="gone")
+            return FakeListResponse(data=[])
+
+        cond.agent_api_participants.list_agent_chat_participants.side_effect = participants
+
+        import thenvoi_rest
+        original = thenvoi_rest.AsyncRestClient
+        thenvoi_rest.AsyncRestClient = factory
+        try:
+            result = await kickoff.reset_stale_rooms(sample_config, tmp_path)
+        finally:
+            thenvoi_rest.AsyncRestClient = original
+
+        assert result == ["stale-room"]
         assert not (tmp_path / ".codeband_room").exists()
 
-        # Every agent's client should have called remove_agent_chat_participant
-        # exactly once with (room_id, agent_id).
+        # Every agent left the stale room exactly once — and never the live room
+        # (assert_called_once_with proves there was no second, live-room call).
         for key, creds in sample_agent_config.agents.items():
             client = factory(creds.api_key)
             client.agent_api_participants.remove_agent_chat_participant.assert_called_once_with(
-                "stale-room-id", creds.agent_id,
+                "stale-room", creds.agent_id,
             )
-
-    @pytest.mark.asyncio
-    async def test_agent_removal_errors_are_swallowed(
-        self, sample_config, sample_agent_config, tmp_path,
-    ):
-        """Agents that can't leave the room (already removed, 404, etc.) don't abort reset."""
-        from codeband.orchestration import kickoff
-
-        sample_agent_config.to_yaml(tmp_path / "agent_config.yaml")
-        (tmp_path / ".codeband_room").write_text("ghost-room", encoding="utf-8")
-
-        factory = _make_clients(AsyncMock(), {
-            creds.api_key: (creds.agent_id, key)
-            for key, creds in sample_agent_config.agents.items()
-        })
-        # Make the conductor's removal raise; the rest should still be called
-        # and the pointer still deleted.
-        cond_client = factory("key-cond")
-        cond_client.agent_api_participants.remove_agent_chat_participant.side_effect = (
-            RuntimeError("404 Not Found")
-        )
-
-        import thenvoi_rest
-        original = thenvoi_rest.AsyncRestClient
-        thenvoi_rest.AsyncRestClient = factory
-        try:
-            result = await kickoff.reset_active_room(sample_config, tmp_path)
-        finally:
-            thenvoi_rest.AsyncRestClient = original
-
-        assert result == "ghost-room"
-        assert not (tmp_path / ".codeband_room").exists()
-        # Mergemaster removal still happened despite conductor failure
-        mm_client = factory("key-mm")
-        mm_client.agent_api_participants.remove_agent_chat_participant.assert_called_once()


### PR DESCRIPTION
## Why

In local mode the Watchdog prints, once per room:
```
Room <uuid> no longer exists — skipping. Run 'cb reset' to clean up stale session state.
```
for every room the Conductor agent is still a member of on Band.ai that was deleted server-side (404 on participant read). But `cb reset` → `reset_active_room` only removed agents from the **single** room in `.codeband_room`, so it never touched the stale rooms the watchdog complains about. The suggestion to "run `cb reset`" was structurally false.

## Change

Replace `reset_active_room` with **`reset_stale_rooms`**:
- Lists the agent's rooms via `agent_api_chats.list_agent_chats()` — the watchdog's own source.
- For each room, applies the **same 404 staleness check** the watchdog uses (`list_agent_chat_participants`). Removes agents **only from stale rooms**; **live rooms are skipped** so concurrent Codeband task rooms are never disturbed.
- **Never deletes rooms** — only `remove_agent_chat_participant` (agents leave). Clears the `.codeband_room` pointer too.
- Listing failure (offline/rate-limited) → no-op.
- Updates the `cb reset` output and the watchdog message/comment to match.

**Best-effort caveat:** a truly phantom server-side membership may also 404 on removal and keep being returned by Band.ai.

## Testing
- New `TestResetStaleRooms` (TDD): only-stale-cleared/live-untouched, listing-failure-non-fatal, no-rooms-noop.
- Full suite: **572 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)