### PR TITLE
Fix broken hero image on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Codeband
 
 <p align="center">
-  <img src="img/codeband-image.png" alt="Codeband" width="1280">
+  <img src="https://raw.githubusercontent.com/thenvoi/codeband/main/img/codeband-image.png" alt="Codeband" width="1280">
 </p>
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
## Problem

On https://pypi.org/project/codeband/ the hero image renders as broken alt text ("Codeband") instead of the actual image.

## Root cause

`README.md` used a relative image path (`img/codeband-image.png`). GitHub resolves relative paths against the repo, so it renders there. PyPI renders the README as a standalone page with no repo base, so the relative path points nowhere and the browser falls back to the alt text. PyPI requires absolute URLs for images.

## Fix

Point the `<img src>` at the raw GitHub URL (`raw.githubusercontent.com/.../main/img/codeband-image.png`), which serves the image bytes and works on both GitHub and PyPI.

## Notes

- PyPI freezes a release's description, so this only takes effect on the **next release** (confirmed acceptable). The GitHub README is correct immediately.
- The "Unable to select next GitHub token from pool" text on the stars badge is a transient shields.io error (its GitHub API token pool was exhausted), unrelated to this change. Left as-is since it self-heals.