### PR TITLE
Catch silent Claude-coder failures: per-model preflight + bundled-CLI doctor check (0.1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeband"
-version = "0.1.1"
+version = "0.1.2"
 description = "Multi-agent coding orchestration via Band.ai"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/codeband/__init__.py
+++ b/src/codeband/__init__.py
@@ -1,3 +1,3 @@
 """Codeband: Multi-agent coding orchestration via Band.ai."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/codeband/doctor.py
+++ b/src/codeband/doctor.py
@@ -139,6 +139,76 @@ def check_claude_cli(_ctx: Context) -> CheckResult:
         )
 
 
+def _cli_version_tuple(version_str: str) -> tuple[int, ...]:
+    """Parse a leading dotted version (e.g. '2.1.81 (Claude Code)') into a tuple."""
+    import re
+
+    match = re.match(r"\s*(\d+(?:\.\d+)*)", version_str or "")
+    if not match:
+        return ()
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _claude_cli_version(command: list[str]) -> str | None:
+    """Return the `--version` string for a Claude Code CLI binary, or None."""
+    try:
+        out = subprocess.run(
+            [*command, "--version"],
+            capture_output=True, text=True, timeout=10, check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return out.stdout.strip() or None
+
+
+def _bundled_claude_cli_path() -> Path | None:
+    """Path to the Claude Code CLI bundled inside claude_agent_sdk, if present."""
+    try:
+        import claude_agent_sdk
+    except Exception:
+        return None
+    candidate = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"
+    return candidate if candidate.exists() else None
+
+
+def check_bundled_claude_cli(_ctx: Context) -> CheckResult:
+    """The Claude SDK shells out to a CLI *bundled* inside `claude_agent_sdk`, not
+    the system `claude`. A stale bundled CLI sends outdated request shapes — e.g.
+    the legacy `thinking.type.enabled` extended-thinking block — that current models
+    reject with a 400. The adapter swallows that error and emits nothing, so the
+    agent connects to its room but silently does no work. Warn when the bundled CLI
+    is older than the system CLI."""
+    bundled = _bundled_claude_cli_path()
+    if bundled is None:
+        return CheckResult(
+            Status.INFO,
+            "No bundled Claude Code CLI (claude_agent_sdk absent or uses system claude)",
+        )
+    bundled_ver = _claude_cli_version([str(bundled)])
+    if bundled_ver is None:
+        return CheckResult(
+            Status.WARN,
+            f"bundled Claude Code CLI present but `--version` failed ({bundled})",
+            remediation="Reinstall the SDK: pip install -U claude-agent-sdk",
+        )
+    system_path = shutil.which("claude")
+    system_ver = _claude_cli_version([system_path]) if system_path else None
+    if system_ver and _cli_version_tuple(system_ver) > _cli_version_tuple(bundled_ver):
+        return CheckResult(
+            Status.WARN,
+            f"bundled Claude Code CLI ({bundled_ver}) is older than the system CLI "
+            f"({system_ver})",
+            remediation=(
+                "Claude agents use the bundled CLI, not the system one. A stale bundled "
+                "CLI sends outdated request shapes that current models reject with a 400 "
+                "(e.g. legacy thinking.type.enabled), which the adapter swallows — the "
+                "agent connects but silently does nothing. Update: "
+                "pip install -U claude-agent-sdk"
+            ),
+        )
+    return CheckResult(Status.OK, f"bundled Claude Code CLI {bundled_ver}")
+
+
 def check_codex_cli(_ctx: Context) -> CheckResult:
     """Gated by `_needs_codex` — only runs when any agent uses Codex."""
     path = shutil.which("codex")
@@ -588,6 +658,7 @@ _CHECKS: list[Check] = [
     Check("Codex auth", "Environment", check_codex_auth, applies_when=_needs_codex),
     Check("git", "Tools", check_git),
     Check("claude CLI", "Tools", check_claude_cli),
+    Check("Bundled Claude CLI", "Tools", check_bundled_claude_cli),
     Check("codex CLI", "Tools", check_codex_cli, applies_when=_needs_codex),
     Check("gh CLI", "Tools", check_gh),
     Check("gh authenticated", "Tools", check_gh_auth),

--- a/src/codeband/preflight.py
+++ b/src/codeband/preflight.py
@@ -16,10 +16,17 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from codeband.models import CLAUDE_SONNET
+from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET
 
 if TYPE_CHECKING:
     from codeband.config import CodebandConfig
+
+# A worker pool whose entry omits `model` falls back to a default at spawn time.
+# That default is Sonnet for every role except coders (Opus) — mirror the
+# spawner here (runner.py: reviewers/plan_reviewers `or CLAUDE_SONNET`, coders
+# via ClaudePlayerRunner's Opus default). Only the non-Sonnet exception needs an
+# entry; everything else — including any pool added later — defaults to Sonnet.
+_POOL_MODEL_DEFAULT: dict[str, str] = {"coders": CLAUDE_OPUS}
 
 logger = logging.getLogger(__name__)
 
@@ -416,38 +423,43 @@ def _config_uses_codex(config: CodebandConfig) -> bool:
 
 
 def _claude_models(config: CodebandConfig) -> list[str]:
-    """Distinct Claude models actually configured across roles, order-preserving.
+    """Distinct Claude models actually configured across *all* roles, order-preserving.
 
-    Each is probed by ``run_preflight`` so a model that rejects the request shape
-    (e.g. a stale bundled CLI sending legacy ``thinking.type.enabled``) fails fast
-    instead of producing a silent, do-nothing agent at runtime. Pool entries with
-    ``model=None`` fall back to the same role default the spawner uses (Opus for
-    coders, Sonnet elsewhere).
+    Discovered generically from the ``AgentsConfig`` fields so new singleton agents
+    or worker pools are probed automatically — there is no role list to keep in sync.
+    Two shapes are recognized (the same ones the rest of the code duck-types):
+
+    * singleton agents expose ``.framework`` + ``.model`` (Conductor, Mergemaster);
+    * worker pools expose ``.entry_for(framework)`` (planners/coders/reviewers/...).
+
+    A pool entry with ``model=None`` falls back to the same default the spawner uses
+    (Opus for coders, Sonnet elsewhere — see ``_POOL_MODEL_DEFAULT``). Each model is
+    probed by ``run_preflight`` so one that rejects the request shape (e.g. a stale
+    bundled CLI sending legacy ``thinking.type.enabled``) fails fast instead of
+    producing a silent, do-nothing agent at runtime.
     """
     from codeband.config import Framework
-    from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET
 
     agents = config.agents
     models: list[str] = []
-    if agents.conductor.framework == Framework.CLAUDE_SDK:
-        models.append(agents.conductor.model)
-    if agents.mergemaster.framework == Framework.CLAUDE_SDK:
-        models.append(agents.mergemaster.model)
-    pool_defaults = {
-        "planners": CLAUDE_SONNET,
-        "plan_reviewers": CLAUDE_SONNET,
-        "coders": CLAUDE_OPUS,
-        "reviewers": CLAUDE_SONNET,
-    }
-    for pool_name, default_model in pool_defaults.items():
-        entry = getattr(agents, pool_name).entry_for(Framework.CLAUDE_SDK)
-        if entry.count > 0:
-            models.append(entry.model or default_model)
+    for field_name in type(agents).model_fields:
+        value = getattr(agents, field_name)
+        if hasattr(value, "framework") and hasattr(value, "model"):
+            # Singleton agent.
+            if value.framework == Framework.CLAUDE_SDK and value.model:
+                models.append(value.model)
+        elif hasattr(value, "entry_for"):
+            # Worker pool.
+            entry = value.entry_for(Framework.CLAUDE_SDK)
+            if entry.count > 0:
+                models.append(
+                    entry.model or _POOL_MODEL_DEFAULT.get(field_name, CLAUDE_SONNET)
+                )
 
     seen: set[str] = set()
     distinct: list[str] = []
     for model in models:
-        if model not in seen:
+        if model and model not in seen:
             seen.add(model)
             distinct.append(model)
     return distinct

--- a/src/codeband/preflight.py
+++ b/src/codeband/preflight.py
@@ -16,6 +16,8 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+from codeband.models import CLAUDE_SONNET
+
 if TYPE_CHECKING:
     from codeband.config import CodebandConfig
 
@@ -42,6 +44,31 @@ class PreflightError:
 # Keep phrases short and specific so one real provider error string matches
 # exactly one pattern.
 _CLAUDE_ERROR_PATTERNS: list[tuple[str, str]] = [
+    (
+        # A 400 the API returns when the request carries an outdated extended-
+        # thinking shape (legacy `thinking.type.enabled`). The usual cause is a
+        # stale Claude Code CLI bundled inside an old `claude-agent-sdk`. band's
+        # adapter swallows this error and emits nothing, so the agent connects
+        # but silently does no work — keep this pattern ahead of the generic
+        # `invalid_request_error` so the remediation is specific.
+        "is not supported for this model",
+        (
+            "A configured Claude model rejected the request shape. This is almost "
+            "always a stale Claude Code CLI bundled inside `claude-agent-sdk` sending "
+            "the legacy `thinking.type.enabled` shape that current models reject. "
+            "Run `pip install -U claude-agent-sdk`, or pin a model that accepts it in "
+            "codeband.yaml. (`cb doctor` reports the bundled CLI version.)"
+        ),
+    ),
+    (
+        "invalid_request_error",
+        (
+            "Anthropic rejected the request as invalid — often a stale Claude Code "
+            "CLI bundled inside `claude-agent-sdk` sending an outdated request shape. "
+            "Run `pip install -U claude-agent-sdk`, or check the configured model in "
+            "codeband.yaml."
+        ),
+    ),
     (
         "credit balance is too low",
         (
@@ -270,12 +297,17 @@ def _restore_openai_api_key_fallback() -> bool:
     return True
 
 
-async def check_claude_auth(auth_mode: str = "api_key") -> PreflightError | None:
+async def check_claude_auth(
+    auth_mode: str = "api_key", model: str = CLAUDE_SONNET
+) -> PreflightError | None:
     """Send one tiny Claude SDK call to verify auth works end-to-end.
 
     Returns ``None`` on success; a ``PreflightError`` describing the
     failure otherwise. The probe uses ``utility_llm.one_shot_text`` so it
-    exercises the exact same auth path as every coding agent.
+    exercises the exact same auth path as every coding agent — including the
+    ``model``, so a model that rejects the request shape (e.g. a stale bundled
+    CLI sending legacy ``thinking.type.enabled``) is caught before agents spawn
+    rather than silently swallowed at runtime.
 
     In the default ``api_key`` mode, an absent ``ANTHROPIC_API_KEY`` is a
     fast, classified failure (no API call): subscription OAuth is never used
@@ -299,7 +331,7 @@ async def check_claude_auth(auth_mode: str = "api_key") -> PreflightError | None
     from codeband.utility_llm import one_shot_text
 
     try:
-        result = await one_shot_text("Reply with just: ok")
+        result = await one_shot_text("Reply with just: ok", model=model)
     except Exception as exc:
         # Usage-limit, auth, and rate-limit failures surface here too: the
         # CLI exits non-zero and ``one_shot_text`` re-raises with stderr
@@ -309,16 +341,16 @@ async def check_claude_auth(auth_mode: str = "api_key") -> PreflightError | None
         message = f"{type(exc).__name__}: {exc}"
         haystack = message.lower()
         if _is_claude_usage_limit(haystack) and _restore_anthropic_api_key_fallback():
-            return await check_claude_auth(auth_mode)
+            return await check_claude_auth(auth_mode, model)
         for pattern, remediation in _CLAUDE_ERROR_PATTERNS:
             if pattern in haystack:
                 return PreflightError(
-                    summary=f"Claude auth check failed: {exc}",
+                    summary=f"Claude auth check failed (model={model}): {exc}",
                     remediation=remediation,
                     classified=True,
                 )
         return PreflightError(
-            summary=f"Claude SDK call raised {message}",
+            summary=f"Claude SDK call raised (model={model}) {message}",
             remediation=(
                 "Check Claude CLI auth (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, "
                 "or macOS keychain via `claude` login) and network connectivity."
@@ -328,11 +360,11 @@ async def check_claude_auth(auth_mode: str = "api_key") -> PreflightError | None
 
     haystack = result.lower()
     if _is_claude_usage_limit(haystack) and _restore_anthropic_api_key_fallback():
-        return await check_claude_auth(auth_mode)
+        return await check_claude_auth(auth_mode, model)
     for pattern, remediation in _CLAUDE_ERROR_PATTERNS:
         if pattern in haystack:
             return PreflightError(
-                summary=f"Claude auth check failed: {result.strip()}",
+                summary=f"Claude auth check failed (model={model}): {result.strip()}",
                 remediation=remediation,
                 classified=True,
             )
@@ -383,19 +415,61 @@ def _config_uses_codex(config: CodebandConfig) -> bool:
     )
 
 
+def _claude_models(config: CodebandConfig) -> list[str]:
+    """Distinct Claude models actually configured across roles, order-preserving.
+
+    Each is probed by ``run_preflight`` so a model that rejects the request shape
+    (e.g. a stale bundled CLI sending legacy ``thinking.type.enabled``) fails fast
+    instead of producing a silent, do-nothing agent at runtime. Pool entries with
+    ``model=None`` fall back to the same role default the spawner uses (Opus for
+    coders, Sonnet elsewhere).
+    """
+    from codeband.config import Framework
+    from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET
+
+    agents = config.agents
+    models: list[str] = []
+    if agents.conductor.framework == Framework.CLAUDE_SDK:
+        models.append(agents.conductor.model)
+    if agents.mergemaster.framework == Framework.CLAUDE_SDK:
+        models.append(agents.mergemaster.model)
+    pool_defaults = {
+        "planners": CLAUDE_SONNET,
+        "plan_reviewers": CLAUDE_SONNET,
+        "coders": CLAUDE_OPUS,
+        "reviewers": CLAUDE_SONNET,
+    }
+    for pool_name, default_model in pool_defaults.items():
+        entry = getattr(agents, pool_name).entry_for(Framework.CLAUDE_SDK)
+        if entry.count > 0:
+            models.append(entry.model or default_model)
+
+    seen: set[str] = set()
+    distinct: list[str] = []
+    for model in models:
+        if model not in seen:
+            seen.add(model)
+            distinct.append(model)
+    return distinct
+
+
 async def run_preflight(config: CodebandConfig) -> PreflightError | None:
     """Run all applicable auth preflight checks concurrently.
 
-    Claude is always checked. Codex is checked only when at least one
-    Codex-framework agent is configured. Both checks are independent CLI
-    cold-starts (~2–5s each) so we run them via :func:`asyncio.gather`
-    and return the first error encountered. Claude wins ties — its check
-    is fed to ``gather`` first, so a Claude error appears at index 0 and
-    is preferred over a coincident Codex error.
+    Every distinct Claude model in the config is probed (not just a default),
+    so a model that rejects the request shape is caught before agents spawn.
+    Codex is checked only when at least one Codex-framework agent is configured.
+    The checks are independent CLI cold-starts (~2–5s each) so we run them via
+    :func:`asyncio.gather` and return the first error encountered. Claude wins
+    ties — its checks are fed to ``gather`` first, so a Claude error is preferred
+    over a coincident Codex error.
     """
     import asyncio
 
-    tasks = [check_claude_auth(config.claude.auth_mode)]
+    tasks = [
+        check_claude_auth(config.claude.auth_mode, model)
+        for model in _claude_models(config)
+    ]
     if _config_uses_codex(config):
         tasks.append(check_codex_auth())
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -25,6 +25,7 @@ from codeband.doctor import (
     Status,
     check_agent_config_yaml,
     check_band_api_key,
+    check_bundled_claude_cli,
     check_claude_auth,
     check_claude_cli,
     check_codeband_yaml,
@@ -80,6 +81,58 @@ def _make_config(tmp_path: Path, *, use_codex: bool = False) -> CodebandConfig:
 
 
 # ─── individual checks ───────────────────────────────────────────────────────
+
+class TestBundledClaudeCli:
+    """Claude agents use the CLI bundled in claude_agent_sdk, not system `claude`.
+    A stale bundled CLI sends request shapes current models reject (400, swallowed
+    by the adapter → silent zombie agent)."""
+
+    @staticmethod
+    def _ctx() -> Context:
+        return Context(project_dir=Path.cwd(), config=None)
+
+    def test_warns_when_bundled_older_than_system(self, monkeypatch, tmp_path):
+        fake = tmp_path / "claude"
+        fake.write_text("")
+        monkeypatch.setattr("codeband.doctor._bundled_claude_cli_path", lambda: fake)
+        monkeypatch.setattr("codeband.doctor.shutil.which", lambda _name: "/usr/bin/claude")
+
+        def ver(command):
+            return (
+                "2.1.81 (Claude Code)"
+                if str(fake) in command[0]
+                else "2.1.179 (Claude Code)"
+            )
+
+        monkeypatch.setattr("codeband.doctor._claude_cli_version", ver)
+        result = check_bundled_claude_cli(self._ctx())
+        assert result.status == Status.WARN
+        assert "claude-agent-sdk" in result.remediation
+
+    def test_ok_when_bundled_current(self, monkeypatch, tmp_path):
+        fake = tmp_path / "claude"
+        fake.write_text("")
+        monkeypatch.setattr("codeband.doctor._bundled_claude_cli_path", lambda: fake)
+        monkeypatch.setattr("codeband.doctor.shutil.which", lambda _name: "/usr/bin/claude")
+        monkeypatch.setattr(
+            "codeband.doctor._claude_cli_version",
+            lambda _command: "2.1.179 (Claude Code)",
+        )
+        result = check_bundled_claude_cli(self._ctx())
+        assert result.status == Status.OK
+
+    def test_info_when_no_bundled_cli(self, monkeypatch):
+        monkeypatch.setattr("codeband.doctor._bundled_claude_cli_path", lambda: None)
+        result = check_bundled_claude_cli(self._ctx())
+        assert result.status == Status.INFO
+
+    def test_version_tuple_parsing(self):
+        from codeband.doctor import _cli_version_tuple
+
+        assert _cli_version_tuple("2.1.81 (Claude Code)") == (2, 1, 81)
+        assert _cli_version_tuple("2.1.179 (Claude Code)") == (2, 1, 179)
+        assert _cli_version_tuple("") == ()
+
 
 class TestClaudeAuth:
     @pytest.fixture(autouse=True)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -74,6 +74,53 @@ class TestCheckClaudeAuth:
         assert "billing" in err.remediation.lower()
 
     @pytest.mark.asyncio
+    async def test_detects_thinking_unsupported_model(self):
+        """The real silent-zombie cause: a stale bundled CLI sends legacy
+        thinking.type.enabled, the model 400s, and the adapter swallows it.
+        Preflight must catch it and point at `claude-agent-sdk`."""
+        from codeband.preflight import check_claude_auth
+
+        # Shape of what one_shot_text surfaces from a ResultMessage.is_error turn.
+        errored = (
+            "result is_error subtype=error_during_execution result='API Error: 400 "
+            '{"type":"error","error":{"type":"invalid_request_error","message":'
+            "\"thinking.type.enabled is not supported for this model. Use "
+            "thinking.type.adaptive\"}}'"
+        )
+        with patch(
+            "codeband.utility_llm.one_shot_text",
+            AsyncMock(return_value=errored),
+        ):
+            err = await check_claude_auth(model="claude-opus-4-7")
+        assert err is not None
+        assert err.classified
+        assert "claude-agent-sdk" in err.remediation
+        assert "claude-opus-4-7" in err.summary
+
+    @pytest.mark.asyncio
+    async def test_detects_invalid_request_error(self):
+        from codeband.preflight import check_claude_auth
+
+        with patch(
+            "codeband.utility_llm.one_shot_text",
+            AsyncMock(return_value="result is_error result='invalid_request_error: bad'"),
+        ):
+            err = await check_claude_auth()
+        assert err is not None
+        assert err.classified
+        assert "claude-agent-sdk" in err.remediation
+
+    @pytest.mark.asyncio
+    async def test_probe_uses_configured_model(self):
+        """The probe must exercise the configured model, not a hardcoded one."""
+        from codeband.preflight import check_claude_auth
+
+        probe = AsyncMock(return_value="ok")
+        with patch("codeband.utility_llm.one_shot_text", probe):
+            await check_claude_auth(model="claude-opus-4-7")
+        assert probe.await_args.kwargs.get("model") == "claude-opus-4-7"
+
+    @pytest.mark.asyncio
     async def test_detects_invalid_api_key(self):
         from codeband.preflight import check_claude_auth
 
@@ -496,6 +543,26 @@ class TestRunPreflight:
             result = await run_preflight(mixed_config)
 
         assert result is codex_err
+
+    @pytest.mark.asyncio
+    async def test_probes_each_distinct_claude_model(self, claude_only_config):
+        """Every distinct configured Claude model is probed — so a model that
+        rejects the request shape (the opus coder) is caught even when the others
+        (sonnet) pass. The default pool puts Opus on coders, Sonnet elsewhere."""
+        from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET
+        from codeband.preflight import run_preflight
+
+        seen_models: list[str] = []
+
+        async def record(_auth_mode, model):
+            seen_models.append(model)
+            return None
+
+        with patch("codeband.preflight.check_claude_auth", side_effect=record):
+            result = await run_preflight(claude_only_config)
+
+        assert result is None
+        assert set(seen_models) == {CLAUDE_OPUS, CLAUDE_SONNET}
 
 
 class TestRunCodexProbe:


### PR DESCRIPTION
## Problem

A Claude coder could connect to its Band room, receive its dispatch, and then **silently do nothing** — no crash, no chat message, nothing the Watchdog could catch — so an assigned subtask sat `pending` forever.

## Root cause (confirmed by live repro)

Reproduced with `cb run --agent coder-claude_sdk-0 --debug` + a human @mention; the debug log showed:

```
band.adapters.claude_sdk: Sending query to Claude SDK (first_msg=True, parts=3)
band.adapters.claude_sdk: Text: API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.en...
band.adapters.claude_sdk: Complete - 348ms, $0.0000
band.adapters.claude_sdk: Message ... processed successfully
```

- The coder ran an Opus model through the **stale Claude Code CLI bundled inside an old `claude-agent-sdk`** (bundled `2.1.81` vs system `2.1.179`).
- That CLI emits the legacy `thinking.type.enabled` request shape, which current models reject with a **400** (`thinking.type.enabled is not supported for this model. Use thinking.type.adaptive`).
- band's `claude_sdk` adapter **swallows the error** (logs at DEBUG, `$0.0000`, marks the message processed) and emits nothing → a healthy-looking zombie.
- It was invisible because preflight only probed a default **Sonnet** model, never the coder's **Opus**; Sonnet still accepts the legacy shape, so the auth probe passed.

## Changes

- **preflight** (`preflight.py`): probe **each distinct configured Claude model** (not a hardcoded default), threading `model` through `check_claude_auth`. New classified patterns for the `invalid_request_error` / `is not supported for this model` 400 with remediation pointing at `pip install -U claude-agent-sdk`. A model that rejects the request shape now **fails `cb run` fast** instead of spawning a silent do-nothing agent.
- **doctor** (`doctor.py`): new **"Bundled Claude CLI"** check — warns when the CLI bundled in `claude_agent_sdk` is older than the system `claude` (agents use the bundled one), with the same remediation.
- **version**: bump to **0.1.2**.

## Deliberately out of scope

Per-turn "zombie" detection *at runtime* is not included: the 400 is swallowed inside band's adapter, which codeband can't intercept without band SDK hooks (`player_claude.py` only exposes `.adapter` to `Agent.create()`). The per-model preflight prevents this specific failure **before** agents spawn, which is the higher-leverage fix.

## Tests

- preflight: detects the `thinking`/`invalid_request` 400; verifies the probe uses the configured model; verifies `run_preflight` probes each distinct model (Opus *and* Sonnet).
- doctor: bundled-vs-system version comparison (WARN when older, OK when current, INFO when absent) + version parsing.
- Full suite: **580 passed**, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)