### PR TITLE
Role registry: one source of truth for the agent roster

### DIFF
--- a/src/codeband/config.py
+++ b/src/codeband/config.py
@@ -226,14 +226,21 @@ class AgentsConfig(_StrictModel):
     watchdog: WatchdogConfig = Field(default_factory=WatchdogConfig)
 
     def total_agent_count(self) -> int:
-        """Band.ai seats used (excluding Watchdog — reuses Conductor creds)."""
-        return (
-            2  # conductor + mergemaster
-            + self.planners.total_count()
-            + self.plan_reviewers.total_count()
-            + self.coders.total_count()
-            + self.reviewers.total_count()
-        )
+        """Band.ai seats used (excluding Watchdog — reuses Conductor creds).
+
+        Derived by introspecting the agent fields (singletons + pools) rather than
+        a hardcoded roster, so a newly added role is counted automatically. A
+        singleton field exposes ``.framework``; a pool field exposes ``.total_count``.
+        Non-agent fields (e.g. ``watchdog``) have neither and are skipped.
+        """
+        total = 0
+        for field_name in type(self).model_fields:
+            value = getattr(self, field_name)
+            if hasattr(value, "total_count"):
+                total += value.total_count()
+            elif hasattr(value, "framework") and hasattr(value, "model"):
+                total += 1
+        return total
 
 
 class RepoConfig(_StrictModel):
@@ -356,7 +363,18 @@ def load_agent_config(project_dir: Path | None = None) -> AgentConfigFile:
     return AgentConfigFile.from_yaml(config_path)
 
 
-_SCALABLE_POOLS = {"planners", "plan_reviewers", "coders", "reviewers"}
+def _scalable_pool_names() -> set[str]:
+    """Names of the scalable worker-pool fields on AgentsConfig.
+
+    Discovered by introspection (a pool exposes ``entry_for``) so a newly added
+    pool is scalable automatically — no hardcoded list to keep in sync.
+    """
+    probe = AgentsConfig()
+    return {
+        name
+        for name in type(probe).model_fields
+        if hasattr(getattr(probe, name), "entry_for")
+    }
 
 
 def scale_pool(
@@ -364,15 +382,16 @@ def scale_pool(
 ) -> CodebandConfig:
     """Set the capacity of a (pool, framework) entry in an existing config.
 
-    `pool` must be one of "planners" / "plan_reviewers" / "coders" / "reviewers".
-    Preserves model/restart settings on the pool entry. Saves the updated
-    config back to disk and returns it.
+    `pool` must be one of the worker pools (planners / plan_reviewers / coders /
+    reviewers). Preserves model/restart settings on the pool entry. Saves the
+    updated config back to disk and returns it.
     """
     if count < 0:
         raise ValueError("count must be >= 0")
-    if pool not in _SCALABLE_POOLS:
+    scalable = _scalable_pool_names()
+    if pool not in scalable:
         raise ValueError(
-            f"Unknown pool '{pool}'. Must be one of: {sorted(_SCALABLE_POOLS)}",
+            f"Unknown pool '{pool}'. Must be one of: {sorted(scalable)}",
         )
 
     config = CodebandConfig.from_yaml(config_path)

--- a/src/codeband/doctor.py
+++ b/src/codeband/doctor.py
@@ -319,18 +319,12 @@ def check_claude_auth(ctx: Context) -> CheckResult:
 
 
 def _needs_codex(ctx: Context) -> bool:
-    """True if any worker pool has a Codex entry with count > 0."""
+    """True if any configured agent runs on the Codex framework."""
     if ctx.config is None:
         return False
-    agents = ctx.config.agents
-    for pool_name in ("planners", "plan_reviewers", "coders", "reviewers"):
-        pool = getattr(agents, pool_name)
-        if pool.entry_for(Framework.CODEX).count > 0:
-            return True
-    return (
-        agents.conductor.framework == Framework.CODEX
-        or agents.mergemaster.framework == Framework.CODEX
-    )
+    from codeband import roster
+
+    return roster.uses_codex(ctx.config)
 
 
 def check_codex_auth(ctx: Context) -> CheckResult:
@@ -466,8 +460,13 @@ def check_cross_model_pairing(ctx: Context) -> CheckResult:
                     f"{critic_count} {opposite.value} reviewers",
                 )
 
-    _check_pair("Planner/Plan Reviewer", agents.planners, agents.plan_reviewers)
-    _check_pair("Coder/Code Reviewer", agents.coders, agents.reviewers)
+    from codeband import roster
+
+    for author_attr, critic_attr in roster.review_pairs():
+        author_spec = roster.spec_for_role(author_attr)
+        critic_spec = roster.spec_for_role(critic_attr)
+        label = f"{author_spec.roster_label}/{critic_spec.roster_label}"
+        _check_pair(label, getattr(agents, author_attr), getattr(agents, critic_attr))
 
     all_issues = issues + capacity_issues
     if all_issues:

--- a/src/codeband/orchestration/runner.py
+++ b/src/codeband/orchestration/runner.py
@@ -16,6 +16,7 @@ from codeband.config import (
     PoolEntry,
     load_agent_config,
 )
+from codeband import roster
 from codeband.models import CLAUDE_SONNET
 from codeband.workers import WorkerId, WorkerRole
 from codeband.workspace.init import initialize_agent_workspace, initialize_workspace
@@ -26,8 +27,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Roles that are always present exactly once per project.
-_SINGLETON_KEYS = ("conductor", "mergemaster")
+# Roles that are always present exactly once per project (from the roster registry).
+_SINGLETON_KEYS = roster.singleton_keys()
 
 # Light stagger between local in-process agent starts. Docker naturally spreads
 # each agent across container startup; plain ``cb`` otherwise opens and joins
@@ -595,6 +596,17 @@ async def run_local(
     )
     logger.info("Created Mergemaster agent")
 
+    # Anti-rot guard: each pool below is spawned with a role-specific factory, so
+    # the loops can't be collapsed — but a *new* pool added to the registry without
+    # a spawn loop here must fail loud, not be silently never-spawned.
+    _spawned_pools = {"planners", "plan_reviewers", "reviewers", "coders"}
+    _unhandled = roster.pool_attrs() - _spawned_pools
+    if _unhandled:
+        raise ValueError(
+            f"run_local has no spawn loop for pool(s) {_unhandled}. Add one (with the "
+            "role's factory/supervision) next to the existing pool loops."
+        )
+
     # --- Planner pool ---
     for wid, _entry in _iter_pool(resolved_config.agents.planners, WorkerRole.PLANNER):
         key = str(wid)
@@ -944,7 +956,7 @@ def _role_from_key(key: str) -> str:
     parts = key.rsplit("-", 2)
     if len(parts) == 3:
         role = parts[0]
-        if role in {"planner", "plan_reviewer", "coder", "reviewer"}:
+        if role in roster.pool_role_values():
             return role
     raise ValueError(f"Cannot derive role from agent key: {key}")
 
@@ -1011,31 +1023,23 @@ def _build_worker_roster(config: CodebandConfig) -> str:
     lines.append("| Role | Framework | Count | Workers |")
     lines.append("|------|-----------|-------|---------|")
 
-    display_role = {
-        WorkerRole.CODER: "Coder",
-        WorkerRole.REVIEWER: "Reviewer",
-        WorkerRole.PLANNER: "Planner",
-        WorkerRole.PLAN_REVIEWER: "Plan-Reviewer",
-    }
-
-    def _display_name(role: WorkerRole, fw: Framework, index: int) -> str:
+    def _display_name(spec: roster.RoleSpec, fw: Framework, index: int) -> str:
         fw_label = "Claude" if fw == Framework.CLAUDE_SDK else "Codex"
-        return f"{display_role[role]}-{fw_label}-{index}"
+        return f"{spec.display_token}-{fw_label}-{index}"
 
-    def _rows(role: WorkerRole, role_label: str, pool: FrameworkPool) -> None:
+    # Driven by the registry so a newly added pool appears here automatically.
+    for spec in roster.pool_specs():
+        pool = getattr(config.agents, spec.config_attr)
         for fw in (Framework.CLAUDE_SDK, Framework.CODEX):
             entry: PoolEntry = pool.entry_for(fw)
             if entry.count == 0:
                 continue
-            workers = ", ".join(_display_name(role, fw, i) for i in range(entry.count))
-            lines.append(
-                f"| {role_label} | {fw.value} | {entry.count} | {workers} |",
+            workers = ", ".join(
+                _display_name(spec, fw, i) for i in range(entry.count)
             )
-
-    _rows(WorkerRole.CODER, "Coder", config.agents.coders)
-    _rows(WorkerRole.REVIEWER, "Code Reviewer", config.agents.reviewers)
-    _rows(WorkerRole.PLANNER, "Planner", config.agents.planners)
-    _rows(WorkerRole.PLAN_REVIEWER, "Plan Reviewer", config.agents.plan_reviewers)
+            lines.append(
+                f"| {spec.roster_label} | {fw.value} | {entry.count} | {workers} |",
+            )
     return "\n".join(lines)
 
 

--- a/src/codeband/orchestration/setup.py
+++ b/src/codeband/orchestration/setup.py
@@ -19,14 +19,14 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from codeband import roster as _roster
 from codeband.config import (
     AgentConfigFile,
     AgentCredentials,
     CodebandConfig,
     Framework,
-    FrameworkPool,
 )
-from codeband.workers import WorkerId, WorkerRole
+from codeband.workers import WorkerId
 
 if TYPE_CHECKING:
     from thenvoi_rest import AsyncRestClient
@@ -49,85 +49,9 @@ _FRAMEWORK_DISPLAY = {
     Framework.CODEX: "Codex",
 }
 
-# Agent descriptions — these are what `band_lookup_peers` returns for
-# discovery-based invites, so each must be self-describing enough that another
-# agent reading the description alone can decide whether to recruit it.
-# Every description includes a stable `role=...` discovery token, and pool
-# descriptions also include `framework=Claude|Codex` so adversarial cross-model
-# pairing rules can filter on exact strings instead of prose.
-#
-# Descriptions are intentionally NOT user-overridable — keep them consistent
-# across deployments so prompts can rely on the wording.
-
-_SINGLETON_AGENTS = {
-    "conductor": (
-        "Conductor",
-        (
-            "Codeband Conductor — orchestration hub. Routes user tasks to a "
-            "Planner, allocates Coders for subtasks, observes Code Reviewer "
-            "verdicts, applies the auto-merge policy (auto-merge low-risk; "
-            "route higher-risk to human approval), and forwards approved PRs "
-            "to the Mergemaster. Relays cross-agent protocols (clarification, "
-            "plan revision, merge conflicts, test failures); intervenes when "
-            "dispatches stall. Singleton; does not plan, code, or review. "
-            "Discovery: role=conductor_agent."
-        ),
-    ),
-    "mergemaster": (
-        "Mergemaster",
-        (
-            "Codeband Mergemaster — integrates approved PRs into the repository "
-            "base branch using a batch-then-bisect strategy. Runs integration "
-            "tests, handles merge conflicts and test failures by routing back "
-            "to the originating Coder via the Conductor. Singleton role; the "
-            "last gate before code reaches main. Discovery: role=merge_agent."
-        ),
-    ),
-}
-
-_POOL_ROLES: tuple[tuple[WorkerRole, str, str], ...] = (
-    (
-        WorkerRole.PLANNER,
-        "planners",
-        (
-            "Codeband Planner — analyzes the codebase and decomposes user "
-            "tasks into independent parallelizable subtasks with acceptance "
-            "criteria. Cross-model paired with a Plan Reviewer on the opposite "
-            "framework. Discovery: role=planning_agent"
-        ),
-    ),
-    (
-        WorkerRole.PLAN_REVIEWER,
-        "plan_reviewers",
-        (
-            "Codeband Plan Reviewer — validates implementation plans before "
-            "Coders begin work. Checks decomposition quality, file conflict "
-            "risk, and acceptance criteria. Cross-model paired with Planners "
-            "on the opposite framework. Discovery: role=plan_review_agent"
-        ),
-    ),
-    (
-        WorkerRole.CODER,
-        "coders",
-        (
-            "Codeband Coder — implements assigned subtasks in an isolated git "
-            "worktree, opens a PR, and dispatches it directly to a Code "
-            "Reviewer on the opposite framework. Cross-model code review is "
-            "the primary value prop of the swarm. Discovery: role=coding_agent"
-        ),
-    ),
-    (
-        WorkerRole.REVIEWER,
-        "reviewers",
-        (
-            "Codeband Code Reviewer — reviews PRs from Coders before merge. "
-            "Cross-model: reviews PRs from Coders on the opposite framework. "
-            "Reports a PASS/FAIL verdict with a risk level "
-            "(low/medium/high/critical) that the Conductor uses to decide "
-            "auto-merge vs human approval. Discovery: role=code_review_agent"
-        ),
-    ),
-)
+# Per-role display labels and Band.ai descriptions now live in the canonical
+# roster registry (`codeband.roster`). This module derives the registration
+# map from it via `_expected_agents`.
 
 
 def worker_display_name(worker_id: WorkerId) -> str:
@@ -143,39 +67,30 @@ _BAND_DESCRIPTION_MAX = 500
 def _expected_agents(config: CodebandConfig) -> dict[str, tuple[str, str]]:
     """Build the full map of agent config-key -> (display_name, description).
 
-    Asserts each description fits within Band.ai's 500-char limit so that a
-    too-long description fails at build time (with a precise pointer to the
-    offending agent) rather than at registration time as an opaque 422 from
-    the platform.
+    Derived from the canonical roster (`codeband.roster`). Asserts each
+    description fits within Band.ai's 500-char limit so a too-long description
+    fails at build time (with a precise pointer to the offending agent) rather
+    than as an opaque 422 at registration time.
     """
+    from codeband import roster
+
     expected: dict[str, tuple[str, str]] = {}
-
-    # Singletons
-    for key, (display, desc) in _SINGLETON_AGENTS.items():
-        expected[key] = (display, desc)
-
-    # Pools — walk (role, attr, base_desc)
-    for role, attr, base_desc in _POOL_ROLES:
-        pool: FrameworkPool = getattr(config.agents, attr)
-        for framework in (Framework.CLAUDE_SDK, Framework.CODEX):
-            entry = pool.entry_for(framework)
-            for i in range(entry.count):
-                wid = WorkerId(role=role, framework=framework, index=i)
-                key = str(wid)
-                display = worker_display_name(wid)
-                desc = (
-                    f"{base_desc}; framework={_FRAMEWORK_DISPLAY[framework]} "
-                    f"({_FRAMEWORK_DISPLAY[framework]})."
-                )
-                expected[key] = (display, desc)
+    for info in roster.iter_agents(config):
+        spec = info.spec
+        if spec.kind == "singleton":
+            expected[info.key] = (spec.roster_label, spec.description)
+        else:
+            fw = _FRAMEWORK_DISPLAY[info.framework]
+            display = worker_display_name(info.worker_id)
+            desc = f"{spec.description}; framework={fw} ({fw})."
+            expected[info.key] = (display, desc)
 
     for key, (display, desc) in expected.items():
         if len(desc) > _BAND_DESCRIPTION_MAX:
             raise ValueError(
                 f"Description for {display} ({key}) is {len(desc)} chars, "
                 f"exceeds Band.ai's {_BAND_DESCRIPTION_MAX}-char limit. "
-                "Trim the canonical description in `_SINGLETON_AGENTS` or "
-                "`_POOL_ROLES` in setup.py."
+                "Trim the canonical description in `_ROLE_SPECS` in roster.py."
             )
 
     return expected
@@ -189,14 +104,12 @@ _LEGACY_AGENT_NAMES = frozenset({
     "Plan Reviewer",    # legacy singleton
     "Code Reviewer",    # legacy singleton
 })
-_CODEBAND_PREFIXES = (
-    "Planner-", "Plan-Reviewer-", "Coder-", "Reviewer-", "Player-",
-)
+_CODEBAND_PREFIXES = _roster.display_prefixes()
 
 
 def _is_codeband_agent(name: str) -> bool:
     """Check if a platform agent name matches Codeband naming conventions."""
-    if name in {"Conductor", "Mergemaster"}:
+    if name in {s.roster_label for s in _roster.singleton_specs()}:
         return True
     if name in _LEGACY_AGENT_NAMES:
         return True
@@ -221,7 +134,7 @@ async def register_all_agents(
 
     `detect_drift=True` (default, for `cb setup-agents`): also re-register
     agents whose platform-side `description` no longer matches the canonical
-    description in `_SINGLETON_AGENTS` / `_POOL_ROLES`. Re-registration
+    description in the roster registry (`codeband.roster`). Re-registration
     rotates the agent's ID and api_key, so any session currently using the
     old credential will fail on next reconnect. The auto-bootstrap path in
     `runner.py:_ensure_agents_registered` passes `detect_drift=False` so that

--- a/src/codeband/orchestration/setup.py
+++ b/src/codeband/orchestration/setup.py
@@ -24,7 +24,6 @@ from codeband.config import (
     AgentConfigFile,
     AgentCredentials,
     CodebandConfig,
-    Framework,
 )
 from codeband.workers import WorkerId
 
@@ -44,20 +43,15 @@ class _DeleteReason(str, Enum):
 
 # ─── naming ─────────────────────────────────────────────────────────────────
 
-_FRAMEWORK_DISPLAY = {
-    Framework.CLAUDE_SDK: "Claude",
-    Framework.CODEX: "Codex",
-}
-
-# Per-role display labels and Band.ai descriptions now live in the canonical
-# roster registry (`codeband.roster`). This module derives the registration
-# map from it via `_expected_agents`.
+# Per-role display labels and Band.ai descriptions live in the canonical roster
+# registry (`codeband.roster`); this module derives the registration map from it
+# via `_expected_agents`.
 
 
 def worker_display_name(worker_id: WorkerId) -> str:
     """Band.ai display name for a pool worker (e.g. `Coder-Claude-0`)."""
     role_label = worker_id.role.value.replace("_", "-").title()
-    fw_label = _FRAMEWORK_DISPLAY[worker_id.framework]
+    fw_label = _roster.FRAMEWORK_DISPLAY[worker_id.framework]
     return f"{role_label}-{fw_label}-{worker_id.index}"
 
 
@@ -72,15 +66,13 @@ def _expected_agents(config: CodebandConfig) -> dict[str, tuple[str, str]]:
     fails at build time (with a precise pointer to the offending agent) rather
     than as an opaque 422 at registration time.
     """
-    from codeband import roster
-
     expected: dict[str, tuple[str, str]] = {}
-    for info in roster.iter_agents(config):
+    for info in _roster.iter_agents(config):
         spec = info.spec
         if spec.kind == "singleton":
             expected[info.key] = (spec.roster_label, spec.description)
         else:
-            fw = _FRAMEWORK_DISPLAY[info.framework]
+            fw = _roster.FRAMEWORK_DISPLAY[info.framework]
             display = worker_display_name(info.worker_id)
             desc = f"{spec.description}; framework={fw} ({fw})."
             expected[info.key] = (display, desc)

--- a/src/codeband/preflight.py
+++ b/src/codeband/preflight.py
@@ -16,17 +16,11 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET
+from codeband.models import CLAUDE_SONNET
 
 if TYPE_CHECKING:
     from codeband.config import CodebandConfig
 
-# A worker pool whose entry omits `model` falls back to a default at spawn time.
-# That default is Sonnet for every role except coders (Opus) — mirror the
-# spawner here (runner.py: reviewers/plan_reviewers `or CLAUDE_SONNET`, coders
-# via ClaudePlayerRunner's Opus default). Only the non-Sonnet exception needs an
-# entry; everything else — including any pool added later — defaults to Sonnet.
-_POOL_MODEL_DEFAULT: dict[str, str] = {"coders": CLAUDE_OPUS}
 
 logger = logging.getLogger(__name__)
 
@@ -403,68 +397,6 @@ def _restore_anthropic_api_key_fallback() -> bool:
     return True
 
 
-def _config_uses_codex(config: CodebandConfig) -> bool:
-    """True if any role in the config runs on the Codex framework.
-
-    Used to scope the Codex preflight — no point shelling out to ``codex exec``
-    on a Claude-only pool.
-    """
-    from codeband.config import Framework
-
-    agents = config.agents
-    for pool_name in ("planners", "plan_reviewers", "coders", "reviewers"):
-        pool = getattr(agents, pool_name)
-        if pool.entry_for(Framework.CODEX).count > 0:
-            return True
-    return (
-        agents.conductor.framework == Framework.CODEX
-        or agents.mergemaster.framework == Framework.CODEX
-    )
-
-
-def _claude_models(config: CodebandConfig) -> list[str]:
-    """Distinct Claude models actually configured across *all* roles, order-preserving.
-
-    Discovered generically from the ``AgentsConfig`` fields so new singleton agents
-    or worker pools are probed automatically — there is no role list to keep in sync.
-    Two shapes are recognized (the same ones the rest of the code duck-types):
-
-    * singleton agents expose ``.framework`` + ``.model`` (Conductor, Mergemaster);
-    * worker pools expose ``.entry_for(framework)`` (planners/coders/reviewers/...).
-
-    A pool entry with ``model=None`` falls back to the same default the spawner uses
-    (Opus for coders, Sonnet elsewhere — see ``_POOL_MODEL_DEFAULT``). Each model is
-    probed by ``run_preflight`` so one that rejects the request shape (e.g. a stale
-    bundled CLI sending legacy ``thinking.type.enabled``) fails fast instead of
-    producing a silent, do-nothing agent at runtime.
-    """
-    from codeband.config import Framework
-
-    agents = config.agents
-    models: list[str] = []
-    for field_name in type(agents).model_fields:
-        value = getattr(agents, field_name)
-        if hasattr(value, "framework") and hasattr(value, "model"):
-            # Singleton agent.
-            if value.framework == Framework.CLAUDE_SDK and value.model:
-                models.append(value.model)
-        elif hasattr(value, "entry_for"):
-            # Worker pool.
-            entry = value.entry_for(Framework.CLAUDE_SDK)
-            if entry.count > 0:
-                models.append(
-                    entry.model or _POOL_MODEL_DEFAULT.get(field_name, CLAUDE_SONNET)
-                )
-
-    seen: set[str] = set()
-    distinct: list[str] = []
-    for model in models:
-        if model and model not in seen:
-            seen.add(model)
-            distinct.append(model)
-    return distinct
-
-
 async def run_preflight(config: CodebandConfig) -> PreflightError | None:
     """Run all applicable auth preflight checks concurrently.
 
@@ -478,11 +410,13 @@ async def run_preflight(config: CodebandConfig) -> PreflightError | None:
     """
     import asyncio
 
+    from codeband import roster
+
     tasks = [
         check_claude_auth(config.claude.auth_mode, model)
-        for model in _claude_models(config)
+        for model in roster.claude_models(config)
     ]
-    if _config_uses_codex(config):
+    if roster.uses_codex(config):
         tasks.append(check_codex_auth())
 
     results = await asyncio.gather(*tasks)

--- a/src/codeband/roster.py
+++ b/src/codeband/roster.py
@@ -1,0 +1,291 @@
+"""Single source of truth for the agent roster.
+
+Every per-role fact — Band.ai display name + description, default Claude model,
+workspace kind, Claude permission profile, cross-model review pairing — lives in
+``_ROLE_SPECS`` here, keyed by the ``AgentsConfig`` field name. Consumers
+(preflight, doctor, runner spawn, workspace layout, setup registration, agent
+counts) derive from this instead of hand-listing the roster.
+
+The anti-rot guarantee: :func:`iter_agents` discovers agent fields by introspecting
+``AgentsConfig`` and asserts every one has a ``RoleSpec``. Adding a role to
+``AgentsConfig`` without registering it here raises at startup — it can no longer
+be silently skipped by spawn/workspace/preflight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+from codeband.config import AgentsConfig, CodebandConfig, Framework
+from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET, CODEX_GPT
+from codeband.workers.pool import WorkerId, WorkerRole
+
+Kind = Literal["singleton", "pool"]
+WorkspaceKind = Literal["worktree", "scratch", "none"]
+ClaudeProfile = Literal["coding", "planner", "plan_reviewer"]
+
+_FRAMEWORK_DISPLAY = {Framework.CLAUDE_SDK: "Claude", Framework.CODEX: "Codex"}
+_BAND_DESCRIPTION_MAX = 500
+
+
+@dataclass(frozen=True)
+class RoleSpec:
+    """Declarative metadata for one agent role (singleton or worker pool)."""
+
+    config_attr: str  # field name on AgentsConfig (e.g. "coders")
+    kind: Kind
+    roster_label: str  # prose label for prompt rosters (e.g. "Code Reviewer")
+    description: str  # Band.ai registration description (base text for pools)
+    worker_role: WorkerRole | None = None  # None for singletons
+    default_claude_model: str = CLAUDE_SONNET  # used when a Claude entry omits model
+    default_codex_model: str = CODEX_GPT
+    workspace_kind: WorkspaceKind = "none"
+    claude_profile: ClaudeProfile | None = None
+    review_pair: str | None = None  # partner config_attr for cross-model review
+
+    @property
+    def display_token(self) -> str:
+        """Band.ai display prefix stem (e.g. "Coder", "Plan-Reviewer", "Conductor")."""
+        if self.worker_role is not None:
+            return self.worker_role.value.replace("_", "-").title()
+        return self.config_attr.title()
+
+
+# Deterministic order: singletons first, then pools (Claude-before-Codex order is
+# applied per-framework inside iter_agents). Descriptions are intentionally NOT
+# user-overridable — kept consistent across deployments so prompts can rely on the
+# wording, and each carries a stable `role=...` discovery token.
+_ROLE_SPECS: tuple[RoleSpec, ...] = (
+    RoleSpec(
+        "conductor", "singleton", "Conductor",
+        (
+            "Codeband Conductor — orchestration hub. Routes user tasks to a "
+            "Planner, allocates Coders for subtasks, observes Code Reviewer "
+            "verdicts, applies the auto-merge policy (auto-merge low-risk; "
+            "route higher-risk to human approval), and forwards approved PRs "
+            "to the Mergemaster. Relays cross-agent protocols (clarification, "
+            "plan revision, merge conflicts, test failures); intervenes when "
+            "dispatches stall. Singleton; does not plan, code, or review. "
+            "Discovery: role=conductor_agent."
+        ),
+        workspace_kind="none",
+    ),
+    RoleSpec(
+        "mergemaster", "singleton", "Mergemaster",
+        (
+            "Codeband Mergemaster — integrates approved PRs into the repository "
+            "base branch using a batch-then-bisect strategy. Runs integration "
+            "tests, handles merge conflicts and test failures by routing back "
+            "to the originating Coder via the Conductor. Singleton role; the "
+            "last gate before code reaches main. Discovery: role=merge_agent."
+        ),
+        workspace_kind="worktree", claude_profile="coding",
+    ),
+    RoleSpec(
+        "planners", "pool", "Planner",
+        (
+            "Codeband Planner — analyzes the codebase and decomposes user "
+            "tasks into independent parallelizable subtasks with acceptance "
+            "criteria. Cross-model paired with a Plan Reviewer on the opposite "
+            "framework. Discovery: role=planning_agent"
+        ),
+        worker_role=WorkerRole.PLANNER, default_claude_model=CLAUDE_SONNET,
+        workspace_kind="worktree", claude_profile="planner",
+        review_pair="plan_reviewers",
+    ),
+    RoleSpec(
+        "plan_reviewers", "pool", "Plan Reviewer",
+        (
+            "Codeband Plan Reviewer — validates implementation plans before "
+            "Coders begin work. Checks decomposition quality, file conflict "
+            "risk, and acceptance criteria. Cross-model paired with Planners "
+            "on the opposite framework. Discovery: role=plan_review_agent"
+        ),
+        worker_role=WorkerRole.PLAN_REVIEWER, default_claude_model=CLAUDE_SONNET,
+        workspace_kind="worktree", claude_profile="plan_reviewer",
+        review_pair="planners",
+    ),
+    RoleSpec(
+        "coders", "pool", "Coder",
+        (
+            "Codeband Coder — implements assigned subtasks in an isolated git "
+            "worktree, opens a PR, and dispatches it directly to a Code "
+            "Reviewer on the opposite framework. Cross-model code review is "
+            "the primary value prop of the swarm. Discovery: role=coding_agent"
+        ),
+        worker_role=WorkerRole.CODER, default_claude_model=CLAUDE_OPUS,
+        workspace_kind="worktree", claude_profile="coding",
+        review_pair="reviewers",
+    ),
+    RoleSpec(
+        "reviewers", "pool", "Code Reviewer",
+        (
+            "Codeband Code Reviewer — reviews PRs from Coders before merge. "
+            "Cross-model: reviews PRs from Coders on the opposite framework. "
+            "Reports a PASS/FAIL verdict with a risk level "
+            "(low/medium/high/critical) that the Conductor uses to decide "
+            "auto-merge vs human approval. Discovery: role=code_review_agent"
+        ),
+        worker_role=WorkerRole.REVIEWER, default_claude_model=CLAUDE_SONNET,
+        workspace_kind="scratch", claude_profile="coding",
+        review_pair="coders",
+    ),
+)
+
+_SPEC_BY_ATTR: dict[str, RoleSpec] = {spec.config_attr: spec for spec in _ROLE_SPECS}
+# Legacy display-name prefix kept for recognizing older registered pool agents.
+_LEGACY_PREFIXES: tuple[str, ...] = ("Player-",)
+
+
+def _agent_field_names(agents: AgentsConfig) -> list[str]:
+    """AgentsConfig field names that describe agents (singletons or pools).
+
+    Duck-typed on the two shapes the rest of the code uses, so a non-agent field
+    (e.g. ``watchdog``, which has neither) is naturally excluded.
+    """
+    names: list[str] = []
+    for field_name in type(agents).model_fields:
+        value = getattr(agents, field_name)
+        is_singleton = hasattr(value, "framework") and hasattr(value, "model")
+        is_pool = hasattr(value, "entry_for")
+        if is_singleton or is_pool:
+            names.append(field_name)
+    return names
+
+
+def _assert_registered(agents: AgentsConfig) -> None:
+    """Fail loud if an agent-shaped config field has no RoleSpec.
+
+    This is the anti-rot guard: a new role added to ``AgentsConfig`` must also be
+    registered here, or startup fails with a precise pointer instead of the role
+    being silently skipped by spawn/workspace/preflight.
+    """
+    missing = [name for name in _agent_field_names(agents) if name not in _SPEC_BY_ATTR]
+    if missing:
+        raise ValueError(
+            f"AgentsConfig field(s) {missing} have no RoleSpec in roster.py. "
+            "Add a RoleSpec to _ROLE_SPECS so the role is spawned, given a "
+            "workspace, probed by preflight, and counted."
+        )
+
+
+@dataclass(frozen=True)
+class AgentInfo:
+    """One configured agent instance (a singleton, or one pool slot)."""
+
+    key: str  # agent_config key: "conductor" or "coder-claude_sdk-0"
+    spec: RoleSpec
+    framework: Framework
+    index: int | None  # None for singletons
+    resolved_model: str  # model after applying per-role defaults
+    worker_id: WorkerId | None  # None for singletons
+
+
+def _resolved_model(spec: RoleSpec, framework: Framework, model: str | None) -> str:
+    if model:
+        return model
+    if framework == Framework.CLAUDE_SDK:
+        return spec.default_claude_model
+    return spec.default_codex_model
+
+
+def iter_agents(config: CodebandConfig) -> Iterator[AgentInfo]:
+    """Yield every configured agent (singletons + pool slots), with resolved models.
+
+    The single roster enumeration: spawn, workspace layout, registration, counts,
+    and preflight all build on this. Asserts the registry is complete first.
+    """
+    agents = config.agents
+    _assert_registered(agents)
+    for spec in _ROLE_SPECS:
+        value = getattr(agents, spec.config_attr)
+        if spec.kind == "singleton":
+            yield AgentInfo(
+                key=spec.config_attr, spec=spec, framework=value.framework,
+                index=None, resolved_model=value.model, worker_id=None,
+            )
+        else:
+            for framework in (Framework.CLAUDE_SDK, Framework.CODEX):
+                entry = value.entry_for(framework)
+                for i in range(entry.count):
+                    wid = WorkerId(role=spec.worker_role, framework=framework, index=i)
+                    yield AgentInfo(
+                        key=str(wid), spec=spec, framework=framework, index=i,
+                        resolved_model=_resolved_model(spec, framework, entry.model),
+                        worker_id=wid,
+                    )
+
+
+# ─── derived helpers (thin views consumers use instead of hardcoded lists) ───
+
+def pool_specs() -> list[RoleSpec]:
+    return [s for s in _ROLE_SPECS if s.kind == "pool"]
+
+
+def singleton_specs() -> list[RoleSpec]:
+    return [s for s in _ROLE_SPECS if s.kind == "singleton"]
+
+
+def pool_attrs() -> set[str]:
+    """Config attr names of scalable pools (replaces hardcoded pool-name sets)."""
+    return {s.config_attr for s in pool_specs()}
+
+
+def pool_role_values() -> set[str]:
+    """`WorkerRole` value strings for the pools (e.g. {'coder','reviewer',...})."""
+    return {s.worker_role.value for s in pool_specs()}
+
+
+def singleton_keys() -> tuple[str, ...]:
+    return tuple(s.config_attr for s in singleton_specs())
+
+
+def spec_for_role(role_value: str) -> RoleSpec | None:
+    """Look up a RoleSpec by role string (pool WorkerRole value or singleton key)."""
+    for spec in _ROLE_SPECS:
+        if spec.config_attr == role_value or (
+            spec.worker_role is not None and spec.worker_role.value == role_value
+        ):
+            return spec
+    return None
+
+
+def display_prefixes() -> tuple[str, ...]:
+    """Display-name prefixes for pool workers (e.g. 'Coder-'), plus legacy aliases."""
+    return tuple(f"{s.display_token}-" for s in pool_specs()) + _LEGACY_PREFIXES
+
+
+def review_pairs() -> list[tuple[str, str]]:
+    """Distinct (config_attr, partner_attr) cross-model review pairs."""
+    seen: set[frozenset[str]] = set()
+    pairs: list[tuple[str, str]] = []
+    for spec in _ROLE_SPECS:
+        if spec.review_pair:
+            key = frozenset({spec.config_attr, spec.review_pair})
+            if key not in seen:
+                seen.add(key)
+                pairs.append((spec.config_attr, spec.review_pair))
+    return pairs
+
+
+def claude_models(config: CodebandConfig) -> list[str]:
+    """Distinct Claude models configured across all roles, order-preserving."""
+    seen: set[str] = set()
+    distinct: list[str] = []
+    for info in iter_agents(config):
+        if info.framework == Framework.CLAUDE_SDK and info.resolved_model:
+            if info.resolved_model not in seen:
+                seen.add(info.resolved_model)
+                distinct.append(info.resolved_model)
+    return distinct
+
+
+def uses_codex(config: CodebandConfig) -> bool:
+    """True if any configured agent runs on the Codex framework."""
+    return any(info.framework == Framework.CODEX for info in iter_agents(config))
+
+
+def total_agent_count(config: CodebandConfig) -> int:
+    """Band.ai seats used (every configured singleton + pool slot)."""
+    return sum(1 for _ in iter_agents(config))

--- a/src/codeband/roster.py
+++ b/src/codeband/roster.py
@@ -25,7 +25,8 @@ Kind = Literal["singleton", "pool"]
 WorkspaceKind = Literal["worktree", "scratch", "none"]
 ClaudeProfile = Literal["coding", "planner", "plan_reviewer"]
 
-_FRAMEWORK_DISPLAY = {Framework.CLAUDE_SDK: "Claude", Framework.CODEX: "Codex"}
+# Human-facing framework labels used in Band.ai display names ("Coder-Claude-0").
+FRAMEWORK_DISPLAY = {Framework.CLAUDE_SDK: "Claude", Framework.CODEX: "Codex"}
 _BAND_DESCRIPTION_MAX = 500
 
 

--- a/src/codeband/workspace/init.py
+++ b/src/codeband/workspace/init.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from codeband import roster
 from codeband.config import CodebandConfig, Framework, FrameworkPool, PoolEntry
 from codeband.workers import WorkerId, WorkerRole
 from codeband.workspace.git import (
@@ -90,14 +91,28 @@ def resolve_layout(config: CodebandConfig) -> WorkspaceLayout:
     )
 
     agents = config.agents
-    for wid in _iter_pool_worker_ids(WorkerRole.PLANNER, agents.planners):
-        layout.planner_worktrees[str(wid)] = worktrees_dir / str(wid)
-    for wid in _iter_pool_worker_ids(WorkerRole.PLAN_REVIEWER, agents.plan_reviewers):
-        layout.plan_reviewer_worktrees[str(wid)] = worktrees_dir / str(wid)
-    for wid in _iter_pool_worker_ids(WorkerRole.CODER, agents.coders):
-        layout.coder_worktrees[str(wid)] = worktrees_dir / str(wid)
-    for wid in _iter_pool_worker_ids(WorkerRole.REVIEWER, agents.reviewers):
-        layout.reviewer_scratch[str(wid)] = root / "scratch" / str(wid)
+    # Registry-driven: each pool's worktree/scratch dir follows its RoleSpec
+    # workspace_kind, so a newly added pool is laid out automatically (or fails
+    # loud below if its target layout field is missing) rather than being
+    # silently omitted. The target dict is the only layout-shape-specific bit.
+    _pool_layout_field = {
+        "planners": "planner_worktrees",
+        "plan_reviewers": "plan_reviewer_worktrees",
+        "coders": "coder_worktrees",
+        "reviewers": "reviewer_scratch",
+    }
+    for spec in roster.pool_specs():
+        field_name = _pool_layout_field.get(spec.config_attr)
+        if field_name is None:
+            raise ValueError(
+                f"resolve_layout has no layout field for pool '{spec.config_attr}'. "
+                "Add one to _pool_layout_field."
+            )
+        base = worktrees_dir if spec.workspace_kind == "worktree" else layout.scratch_dir
+        target = getattr(layout, field_name)
+        pool = getattr(agents, spec.config_attr)
+        for wid in _iter_pool_worker_ids(spec.worker_role, pool):
+            target[str(wid)] = base / str(wid)
 
     return layout
 
@@ -215,9 +230,6 @@ class AgentWorkspaceLayout:
     notes_dir: Path | None
 
 
-_WORKTREE_ROLES = {"planner", "plan_reviewer", "coder", "mergemaster"}
-
-
 def initialize_agent_workspace(
     config: CodebandConfig,
     worker_id: str,
@@ -298,14 +310,9 @@ def initialize_agent_workspace(
 
 
 def _claude_profile_for_agent_role(agent_role: str) -> ClaudeSettingsProfile | None:
-    """Map an agent role to the Claude permission profile it should use."""
-    if agent_role in {"coder", "mergemaster"}:
-        return "coding"
-    if agent_role == "planner":
-        return "planner"
-    if agent_role == "plan_reviewer":
-        return "plan_reviewer"
-    return None
+    """Map an agent role to the Claude permission profile it should use (roster)."""
+    spec = roster.spec_for_role(agent_role)
+    return spec.claude_profile if spec else None
 
 
 _CLAUDE_SETTINGS_PROFILES: dict[ClaudeSettingsProfile, dict] = {

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,127 @@
+"""Tests for the canonical agent roster registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeband.config import (
+    AgentsConfig,
+    CodebandConfig,
+    Framework,
+    FrameworkPool,
+    PlanReviewersConfig,
+    PoolEntry,
+    RepoConfig,
+    ReviewersConfig,
+)
+from codeband.models import CLAUDE_OPUS, CLAUDE_SONNET, CODEX_GPT
+from codeband import roster
+
+
+def _config(agents: AgentsConfig | None = None) -> CodebandConfig:
+    return CodebandConfig(
+        repo=RepoConfig(url="https://github.com/x/y"),
+        agents=agents or AgentsConfig(),
+    )
+
+
+class TestCompletenessGuard:
+    def test_every_agent_field_is_registered(self):
+        """Anti-rot: each agent-shaped AgentsConfig field must have a RoleSpec.
+        Add a field to AgentsConfig without a RoleSpec and this fails."""
+        agents = AgentsConfig()
+        for name in roster._agent_field_names(agents):
+            assert name in roster._SPEC_BY_ATTR, f"{name} has no RoleSpec"
+
+    def test_watchdog_is_not_treated_as_an_agent(self):
+        # watchdog has neither the singleton nor the pool shape.
+        assert "watchdog" not in roster._agent_field_names(AgentsConfig())
+
+    def test_iter_agents_raises_on_unregistered_field(self, monkeypatch):
+        trimmed = dict(roster._SPEC_BY_ATTR)
+        trimmed.pop("coders")
+        monkeypatch.setattr(roster, "_SPEC_BY_ATTR", trimmed)
+        with pytest.raises(ValueError, match="coders"):
+            list(roster.iter_agents(_config()))
+
+
+class TestIterAgents:
+    def test_default_config_yields_expected_keys(self):
+        keys = {info.key for info in roster.iter_agents(_config())}
+        assert keys == {
+            "conductor",
+            "mergemaster",
+            "planner-claude_sdk-0",
+            "plan_reviewer-codex-0",
+            "coder-claude_sdk-0",
+            "coder-codex-0",
+            "reviewer-claude_sdk-0",
+            "reviewer-codex-0",
+        }
+
+    def test_pool_model_defaults_match_spawner(self):
+        # Claude coder/reviewer with model unset → Opus for coders, Sonnet for reviewers.
+        agents = AgentsConfig(
+            coders=FrameworkPool(claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)),
+            reviewers=ReviewersConfig(claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)),
+        )
+        by_key = {i.key: i for i in roster.iter_agents(_config(agents))}
+        assert by_key["coder-claude_sdk-0"].resolved_model == CLAUDE_OPUS
+        assert by_key["reviewer-claude_sdk-0"].resolved_model == CLAUDE_SONNET
+
+    def test_explicit_model_is_honored(self):
+        agents = AgentsConfig(
+            coders=FrameworkPool(
+                claude_sdk=PoolEntry(count=1, model="claude-opus-4-7"),
+                codex=PoolEntry(count=0),
+            ),
+        )
+        by_key = {i.key: i for i in roster.iter_agents(_config(agents))}
+        assert by_key["coder-claude_sdk-0"].resolved_model == "claude-opus-4-7"
+
+    def test_codex_model_default(self):
+        info = next(
+            i for i in roster.iter_agents(_config()) if i.key == "coder-codex-0"
+        )
+        assert info.framework == Framework.CODEX
+        assert info.resolved_model == CODEX_GPT
+
+
+class TestDerivedHelpers:
+    def test_claude_models_distinct_and_ordered(self):
+        # Default: conductor/mergemaster/planner/reviewer Sonnet + coder Opus.
+        assert roster.claude_models(_config()) == [CLAUDE_SONNET, CLAUDE_OPUS]
+
+    def test_uses_codex(self):
+        assert roster.uses_codex(_config()) is True
+        claude_only = AgentsConfig(
+            planners=FrameworkPool(claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)),
+            plan_reviewers=PlanReviewersConfig(
+                claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)
+            ),
+            coders=FrameworkPool(claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)),
+            reviewers=ReviewersConfig(claude_sdk=PoolEntry(count=1), codex=PoolEntry(count=0)),
+        )
+        assert roster.uses_codex(_config(claude_only)) is False
+
+    def test_total_agent_count_matches_iteration(self):
+        cfg = _config()
+        assert roster.total_agent_count(cfg) == len(list(roster.iter_agents(cfg)))
+        assert roster.total_agent_count(cfg) == 8  # 2 singletons + 1+1+2+2 pools
+
+    def test_pool_and_singleton_views(self):
+        assert roster.pool_attrs() == {"planners", "plan_reviewers", "coders", "reviewers"}
+        assert roster.singleton_keys() == ("conductor", "mergemaster")
+        assert roster.pool_role_values() == {"planner", "plan_reviewer", "coder", "reviewer"}
+
+    def test_review_pairs(self):
+        pairs = {frozenset(p) for p in roster.review_pairs()}
+        assert pairs == {
+            frozenset({"planners", "plan_reviewers"}),
+            frozenset({"coders", "reviewers"}),
+        }
+
+    def test_display_prefixes(self):
+        prefixes = roster.display_prefixes()
+        for expected in ("Planner-", "Plan-Reviewer-", "Coder-", "Reviewer-", "Player-"):
+            assert expected in prefixes

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -176,13 +176,21 @@ def test_expected_agent_descriptions_within_band_500_char_limit():
 def test_oversized_description_raises_at_build_time(monkeypatch):
     """If a future edit makes a description too long, the build fails with a
     clear error rather than waiting until Band.ai returns 422."""
+    import dataclasses
+
+    from codeband import roster
     from codeband.orchestration import setup as setup_mod
 
-    # Inflate one singleton's description past the limit.
-    bloated = ("X" * 600)
-    monkeypatch.setitem(
-        setup_mod._SINGLETON_AGENTS, "conductor", ("Conductor", bloated),
+    # Inflate one role's canonical description (now owned by the roster) past
+    # the limit, leaving the rest of the registry intact.
+    bloated = "X" * 600
+    patched = tuple(
+        dataclasses.replace(spec, description=bloated)
+        if spec.config_attr == "conductor"
+        else spec
+        for spec in roster._ROLE_SPECS
     )
+    monkeypatch.setattr(roster, "_ROLE_SPECS", patched)
 
     with pytest.raises(ValueError, match=r"exceeds Band.ai's 500-char limit"):
         setup_mod._expected_agents(_make_config())


### PR DESCRIPTION
## Why

The agent roster — 2 singletons (`conductor`, `mergemaster`) + 4 pools (`planners`, `plan_reviewers`, `coders`, `reviewers`) — was hand-enumerated in **18 sites across 7 files**. Adding a role meant editing all of them, and several misses were **silent**: a new pool would never be spawned, never get a workspace, and be skipped by preflight — the same "looks fine, does nothing" failure class as the zombie-coder bug that started this thread.

> Stacked on #17 (base = `fix/claude-zombie-turn-detection`) so the diff is just the refactor. Rebase to `main` once #17 merges.

## What

New **`codeband/roster.py`** — the single source of truth:
- a declarative `RoleSpec` per role (default model, Band display name/description, `workspace_kind`, Claude permission profile, cross-model review pairing);
- `iter_agents(config)` discovers agents by introspecting `AgentsConfig` (duck-typing the singleton vs pool shapes) and **asserts every agent field has a `RoleSpec`** — an unregistered role raises at startup instead of being silently skipped;
- thin derived helpers: `claude_models`, `uses_codex`, `total_agent_count`, `pool_specs`, `singleton_keys`, `pool_role_values`, `review_pairs`, `display_prefixes`, `spec_for_role`.

Consumers routed through it (deleting their local hardcoded lists):
- **preflight** — `claude_models` / `uses_codex` (drops the duplicated default-model map).
- **doctor** — codex-detection + cross-model pairing iterate the registry.
- **config** — `total_agent_count` and `scale_pool` validity via introspection (no `2  # conductor + mergemaster`, no `_SCALABLE_POOLS`).
- **setup** — `_expected_agents` + prefixes built from the registry; canonical descriptions moved into `roster.py`.
- **runner** — singleton keys, role-key validation, and the prompt worker-roster table.
- **workspace** — `resolve_layout` + Claude-profile lookup; dropped dead `_WORKTREE_ROLES`.

## Deliberately left for a follow-up (out of Core scope)

Spawn loops (`run_local`) and the workspace layout stay role-specific — they bind to per-role **factories / named layout fields** (behavior, not data) — but now carry **fail-loud guards** so a new pool can't be silently dropped. Terminal colors (`feed.py`), the `run_agent`/workspace dispatch trees, and Docker-compose profile gates are untouched.

## Tests

- New `tests/test_roster.py` incl. the **anti-rot guard**: every `AgentsConfig` agent field must have a `RoleSpec` (add a field without one → test fails), and `iter_agents` raises on an unregistered agent-shaped field.
- Equivalence held via existing suites (setup `_expected_agents`, doctor, preflight, config, prompt-invariants).
- Full suite **593 passed**, `ruff` clean. Smoke: `iter_agents` over the loguru config lists all 8 agents with correct resolved models; `cb doctor` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)